### PR TITLE
Expose underlying data for BigUint and BigInt.

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -811,8 +811,8 @@ impl BigUint {
     }
 
     /// Returns a reference to the underlying data for the `BigUint`
-    pub fn data(&self) -> &Vec<BigDigit> {
-        &self.data
+    pub fn data(&self) -> &[BigDigit] {
+        self.data.as_slice()
     }
 }
 
@@ -1424,7 +1424,7 @@ impl BigInt {
     }
 
     /// Returns a reference to the underlying data for the `BigUint`
-    pub fn data(&self) -> &Vec<BigDigit> {
+    pub fn data(&self) -> &[BigDigit] {
         self.data.data()
     }
 }

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -809,6 +809,11 @@ impl BigUint {
         let zeros = self.data.last().unwrap().leading_zeros();
         return self.data.len()*BigDigit::bits - zeros;
     }
+
+    /// Returns a reference to the underlying data for the `BigUint`
+    pub fn data(&self) -> &Vec<BigDigit> {
+        &self.data
+    }
 }
 
 // `DoubleBigDigit` size dependent
@@ -1416,6 +1421,11 @@ impl BigInt {
             Zero => Some(Zero::zero()),
             Minus => None
         }
+    }
+
+    /// Returns a reference to the underlying data for the `BigUint`
+    pub fn data(&self) -> &Vec<BigDigit> {
+        self.data.data()
     }
 }
 


### PR DESCRIPTION
It would be useful to have access to the underlying data used to represent these numbers for use in certain algorithms that can be optimized with access to the underlying data as seen in:
ftp://ftp.cs.pdx.edu/smn/ipsec/skip/bnlib/jacobi.c

Perhaps another way to go about this would be to implement the Index trait for these two data types.