### PR TITLE
Fix warning about renamed missing doc attribute.

### DIFF
--- a/src/rational.rs
+++ b/src/rational.rs
@@ -22,7 +22,7 @@ use bigint::{BigInt, BigUint, Sign, Plus, Minus};
 
 /// Represents the ratio between 2 numbers.
 #[deriving(Clone, Hash)]
-#[allow(missing_doc)]
+#[allow(missing_docs)]
 pub struct Ratio<T> {
     numer: T,
     denom: T


### PR DESCRIPTION
The missing_doc attribute was renamed to missing_docs.
