### PR TITLE
update to latest rustc

### DIFF
--- a/benches/shootout-pidigits.rs
+++ b/benches/shootout-pidigits.rs
@@ -70,24 +70,24 @@ impl Context {
     fn extract_digit(&self) -> int {
         if self.numer > self.accum {return -1;}
         let (q, r) =
-            (self.numer * Context::from_int(3) + self.accum)
+            (&self.numer * Context::from_int(3) + &self.accum)
             .div_rem(&self.denom);
-        if r + self.numer >= self.denom {return -1;}
+        if r + &self.numer >= self.denom {return -1;}
         q.to_int().unwrap()
     }
 
     fn next_term(&mut self, k: int) {
         let y2 = Context::from_int(k * 2 + 1);
-        self.accum = (self.accum + (self.numer << 1)) * y2;
-        self.numer = self.numer * Context::from_int(k);
-        self.denom = self.denom * y2;
+        self.accum = (&self.accum + (&self.numer << 1)) * &y2;
+        self.numer = &self.numer * Context::from_int(k);
+        self.denom = &self.denom * y2;
     }
 
     fn eliminate_digit(&mut self, d: int) {
         let d = Context::from_int(d);
         let ten = Context::from_int(10);
-        self.accum = (self.accum - self.denom * d) * ten;
-        self.numer = self.numer * ten;
+        self.accum = (&self.accum - &self.denom * d) * &ten;
+        self.numer = &self.numer * ten;
     }
 }
 

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -134,9 +134,7 @@ pub trait Integer: Num + PartialOrd
     /// assert_eq!((-1i).div_rem(&-2), ( 0, -1));
     /// ~~~
     #[inline]
-    fn div_rem(&self, other: &Self) -> (Self, Self) {
-        (*self / *other, *self % *other)
-    }
+    fn div_rem(&self, other: &Self) -> (Self, Self);
 
     /// Simultaneous floored integer division and modulus.
     /// Returns `(quotient, remainder)`.
@@ -253,6 +251,12 @@ macro_rules! impl_integer_for_int {
             /// Returns `true` if the number is not divisible by `2`
             #[inline]
             fn is_odd(&self) -> bool { !self.is_even() }
+
+            /// Simultaneous truncated integer division and modulus.
+            #[inline]
+            fn div_rem(&self, other: &$T) -> ($T, $T) {
+                (*self / *other, *self % *other)
+            }
         }
 
         #[cfg(test)]
@@ -425,6 +429,12 @@ macro_rules! impl_integer_for_uint {
             /// Returns `true` if the number is not divisible by `2`.
             #[inline]
             fn is_odd(&self) -> bool { !(*self).is_even() }
+
+            /// Simultaneous truncated integer division and modulus.
+            #[inline]
+            fn div_rem(&self, other: &$T) -> ($T, $T) {
+                (*self / *other, *self % *other)
+            }
         }
 
         #[cfg(test)]

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -45,7 +45,7 @@ impl<A: Add<A, A> + PartialOrd + Clone + ToPrimitive> Iterator<A> for Range<A> {
     fn next(&mut self) -> Option<A> {
         if self.state < self.stop {
             let result = self.state.clone();
-            self.state = self.state + self.one;
+            self.state = self.state.clone() + self.one.clone();
             Some(result)
         } else {
             None
@@ -91,7 +91,7 @@ impl<A: Integer + PartialOrd + Clone + ToPrimitive> DoubleEndedIterator<A> for R
     #[inline]
     fn next_back(&mut self) -> Option<A> {
         if self.stop > self.state {
-            self.stop = self.stop - self.one;
+            self.stop = self.stop.clone() - self.one.clone();
             Some(self.stop.clone())
         } else {
             None
@@ -151,7 +151,7 @@ impl<A: Sub<A, A> + Integer + PartialOrd + Clone + ToPrimitive> DoubleEndedItera
     fn next_back(&mut self) -> Option<A> {
         if self.range.stop > self.range.state {
             let result = self.range.stop.clone();
-            self.range.stop = self.range.stop - self.range.one;
+            self.range.stop = self.range.stop.clone() - self.range.one.clone();
             Some(result)
         } else if !self.done && self.range.state == self.range.stop {
             self.done = true;
@@ -246,7 +246,7 @@ mod tests {
         }
 
         impl Add<Foo, Foo> for Foo {
-            fn add(&self, _: &Foo) -> Foo {
+            fn add(self, _: Foo) -> Foo {
                 Foo
             }
         }
@@ -270,7 +270,7 @@ mod tests {
         }
 
         impl Mul<Foo, Foo> for Foo {
-            fn mul(&self, _: &Foo) -> Foo {
+            fn mul(self, _: Foo) -> Foo {
                 Foo
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!     let mut approx = start.clone();
 //!
 //!     for _ in range(0, iterations) {
-//!         approx = (approx + (start / approx)) /
+//!         approx = (&approx + (&start / &approx)) /
 //!             Ratio::from_integer(FromPrimitive::from_u64(2).unwrap());
 //!     }
 //!
@@ -123,15 +123,15 @@ pub fn abs_sub<T: Signed>(x: T, y: T) -> T {
 /// assert_eq!(num::pow(2i, 4), 16);
 /// ```
 #[inline]
-pub fn pow<T: One + Mul<T, T>>(mut base: T, mut exp: uint) -> T {
+pub fn pow<T: Clone + One + Mul<T, T>>(mut base: T, mut exp: uint) -> T {
     if exp == 1 { base }
     else {
         let mut acc = one::<T>();
         while exp > 0 {
             if (exp & 1) == 1 {
-                acc = acc * base;
+                acc = acc * base.clone();
             }
-            base = base * base;
+            base = base.clone() * base;
             exp = exp >> 1;
         }
         acc


### PR DESCRIPTION
Now, arithmetic binary operator traits take operands by value, but non-copyable types such as `BigUint` should not always moved out when applying operators.

This commit implements these operators not only for bare structs but also for these references. By-value implementations are forwarded to by-reference implementations for now. In the future, by-value implementations may be replaced with more efficient implementations (for example, the implementation that re-uses moved buffer.)
