### PR TITLE
Add semicolons to macro lines

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -218,13 +218,13 @@ macro_rules! forward_val_ref_binop {
 
 macro_rules! forward_all_binop {
     (impl $imp:ident for $res:ty, $method:ident) => {
-        forward_val_val_binop!(impl $imp for $res, $method)
-        forward_ref_val_binop!(impl $imp for $res, $method)
-        forward_val_ref_binop!(impl $imp for $res, $method)
+        forward_val_val_binop!(impl $imp for $res, $method);
+        forward_ref_val_binop!(impl $imp for $res, $method);
+        forward_val_ref_binop!(impl $imp for $res, $method);
     };
 }
 
-forward_all_binop!(impl BitAnd for BigUint, bitand)
+forward_all_binop!(impl BitAnd for BigUint, bitand);
 
 impl<'a, 'b> BitAnd<&'b BigUint, BigUint> for &'a BigUint {
     #[inline]
@@ -233,7 +233,7 @@ impl<'a, 'b> BitAnd<&'b BigUint, BigUint> for &'a BigUint {
     }
 }
 
-forward_all_binop!(impl BitOr for BigUint, bitor)
+forward_all_binop!(impl BitOr for BigUint, bitor);
 
 impl<'a, 'b> BitOr<&'b BigUint, BigUint> for &'a BigUint {
     fn bitor(self, other: &BigUint) -> BigUint {
@@ -246,7 +246,7 @@ impl<'a, 'b> BitOr<&'b BigUint, BigUint> for &'a BigUint {
     }
 }
 
-forward_all_binop!(impl BitXor for BigUint, bitxor)
+forward_all_binop!(impl BitXor for BigUint, bitxor);
 
 impl<'a, 'b> BitXor<&'b BigUint, BigUint> for &'a BigUint {
     fn bitxor(self, other: &BigUint) -> BigUint {
@@ -302,7 +302,7 @@ impl One for BigUint {
 
 impl Unsigned for BigUint {}
 
-forward_all_binop!(impl Add for BigUint, add)
+forward_all_binop!(impl Add for BigUint, add);
 
 impl<'a, 'b> Add<&'b BigUint, BigUint> for &'a BigUint {
     fn add(self, other: &BigUint) -> BigUint {
@@ -321,7 +321,7 @@ impl<'a, 'b> Add<&'b BigUint, BigUint> for &'a BigUint {
     }
 }
 
-forward_all_binop!(impl Sub for BigUint, sub)
+forward_all_binop!(impl Sub for BigUint, sub);
 
 impl<'a, 'b> Sub<&'b BigUint, BigUint> for &'a BigUint {
     fn sub(self, other: &BigUint) -> BigUint {
@@ -352,7 +352,7 @@ impl<'a, 'b> Sub<&'b BigUint, BigUint> for &'a BigUint {
 }
 
 
-forward_all_binop!(impl Mul for BigUint, mul)
+forward_all_binop!(impl Mul for BigUint, mul);
 
 impl<'a, 'b> Mul<&'b BigUint, BigUint> for &'a BigUint {
     fn mul(self, other: &BigUint) -> BigUint {
@@ -421,7 +421,7 @@ impl<'a, 'b> Mul<&'b BigUint, BigUint> for &'a BigUint {
 }
 
 
-forward_all_binop!(impl Div for BigUint, div)
+forward_all_binop!(impl Div for BigUint, div);
 
 impl<'a, 'b> Div<&'b BigUint, BigUint> for &'a BigUint {
     #[inline]
@@ -431,7 +431,7 @@ impl<'a, 'b> Div<&'b BigUint, BigUint> for &'a BigUint {
     }
 }
 
-forward_all_binop!(impl Rem for BigUint, rem)
+forward_all_binop!(impl Rem for BigUint, rem);
 
 impl<'a, 'b> Rem<&'b BigUint, BigUint> for &'a BigUint {
     #[inline]
@@ -702,7 +702,7 @@ impl ToBigUint for BigUint {
     }
 }
 
-macro_rules! impl_to_biguint(
+macro_rules! impl_to_biguint {
     ($T:ty, $from_ty:path) => {
         impl ToBigUint for $T {
             #[inline]
@@ -711,18 +711,18 @@ macro_rules! impl_to_biguint(
             }
         }
     }
-)
+}
 
-impl_to_biguint!(int,  FromPrimitive::from_int)
-impl_to_biguint!(i8,   FromPrimitive::from_i8)
-impl_to_biguint!(i16,  FromPrimitive::from_i16)
-impl_to_biguint!(i32,  FromPrimitive::from_i32)
-impl_to_biguint!(i64,  FromPrimitive::from_i64)
-impl_to_biguint!(uint, FromPrimitive::from_uint)
-impl_to_biguint!(u8,   FromPrimitive::from_u8)
-impl_to_biguint!(u16,  FromPrimitive::from_u16)
-impl_to_biguint!(u32,  FromPrimitive::from_u32)
-impl_to_biguint!(u64,  FromPrimitive::from_u64)
+impl_to_biguint!(int,  FromPrimitive::from_int);
+impl_to_biguint!(i8,   FromPrimitive::from_i8);
+impl_to_biguint!(i16,  FromPrimitive::from_i16);
+impl_to_biguint!(i32,  FromPrimitive::from_i32);
+impl_to_biguint!(i64,  FromPrimitive::from_i64);
+impl_to_biguint!(uint, FromPrimitive::from_uint);
+impl_to_biguint!(u8,   FromPrimitive::from_u8);
+impl_to_biguint!(u16,  FromPrimitive::from_u16);
+impl_to_biguint!(u32,  FromPrimitive::from_u32);
+impl_to_biguint!(u64,  FromPrimitive::from_u64);
 
 fn to_str_radix(me: &BigUint, radix: uint) -> String {
     assert!(1 < radix && radix <= 16, "The radix must be within (1, 16]");
@@ -1077,7 +1077,7 @@ impl Signed for BigInt {
     fn is_negative(&self) -> bool { self.sign == Minus }
 }
 
-forward_all_binop!(impl Add for BigInt, add)
+forward_all_binop!(impl Add for BigInt, add);
 
 impl<'a, 'b> Add<&'b BigInt, BigInt> for &'a BigInt {
     #[inline]
@@ -1093,7 +1093,7 @@ impl<'a, 'b> Add<&'b BigInt, BigInt> for &'a BigInt {
     }
 }
 
-forward_all_binop!(impl Sub for BigInt, sub)
+forward_all_binop!(impl Sub for BigInt, sub);
 
 impl<'a, 'b> Sub<&'b BigInt, BigInt> for &'a BigInt {
     #[inline]
@@ -1113,7 +1113,7 @@ impl<'a, 'b> Sub<&'b BigInt, BigInt> for &'a BigInt {
     }
 }
 
-forward_all_binop!(impl Mul for BigInt, mul)
+forward_all_binop!(impl Mul for BigInt, mul);
 
 impl<'a, 'b> Mul<&'b BigInt, BigInt> for &'a BigInt {
     #[inline]
@@ -1130,7 +1130,7 @@ impl<'a, 'b> Mul<&'b BigInt, BigInt> for &'a BigInt {
     }
 }
 
-forward_all_binop!(impl Div for BigInt, div)
+forward_all_binop!(impl Div for BigInt, div);
 
 impl<'a, 'b> Div<&'b BigInt, BigInt> for &'a BigInt {
     #[inline]
@@ -1140,7 +1140,7 @@ impl<'a, 'b> Div<&'b BigInt, BigInt> for &'a BigInt {
     }
 }
 
-forward_all_binop!(impl Rem for BigInt, rem)
+forward_all_binop!(impl Rem for BigInt, rem);
 
 impl<'a, 'b> Rem<&'b BigInt, BigInt> for &'a BigInt {
     #[inline]
@@ -1359,7 +1359,7 @@ impl ToBigInt for BigUint {
     }
 }
 
-macro_rules! impl_to_bigint(
+macro_rules! impl_to_bigint {
     ($T:ty, $from_ty:path) => {
         impl ToBigInt for $T {
             #[inline]
@@ -1368,18 +1368,18 @@ macro_rules! impl_to_bigint(
             }
         }
     }
-)
+}
 
-impl_to_bigint!(int,  FromPrimitive::from_int)
-impl_to_bigint!(i8,   FromPrimitive::from_i8)
-impl_to_bigint!(i16,  FromPrimitive::from_i16)
-impl_to_bigint!(i32,  FromPrimitive::from_i32)
-impl_to_bigint!(i64,  FromPrimitive::from_i64)
-impl_to_bigint!(uint, FromPrimitive::from_uint)
-impl_to_bigint!(u8,   FromPrimitive::from_u8)
-impl_to_bigint!(u16,  FromPrimitive::from_u16)
-impl_to_bigint!(u32,  FromPrimitive::from_u32)
-impl_to_bigint!(u64,  FromPrimitive::from_u64)
+impl_to_bigint!(int,  FromPrimitive::from_int);
+impl_to_bigint!(i8,   FromPrimitive::from_i8);
+impl_to_bigint!(i16,  FromPrimitive::from_i16);
+impl_to_bigint!(i32,  FromPrimitive::from_i32);
+impl_to_bigint!(i64,  FromPrimitive::from_i64);
+impl_to_bigint!(uint, FromPrimitive::from_uint);
+impl_to_bigint!(u8,   FromPrimitive::from_u8);
+impl_to_bigint!(u16,  FromPrimitive::from_u16);
+impl_to_bigint!(u32,  FromPrimitive::from_u32);
+impl_to_bigint!(u64,  FromPrimitive::from_u64);
 
 impl FromStrRadix for BigInt {
     /// Creates and initializes a BigInt.
@@ -2615,7 +2615,7 @@ mod bigint_tests {
             assert!(&c + (-b) == a);
             assert!(&a + (-c) == (-b));
             assert!(&b + (-c) == (-a));
-            assert!((-a) + (-b) == (-c))
+            assert!((-a) + (-b) == (-c));
             assert!(&a + (-a) == Zero::zero());
         }
     }
@@ -2630,8 +2630,8 @@ mod bigint_tests {
 
             assert!(&c - &a == b);
             assert!(&c - &b == a);
-            assert!((-b) - &a == (-c))
-            assert!((-a) - &b == (-c))
+            assert!((-b) - &a == (-c));
+            assert!((-a) - &b == (-c));
             assert!(&b - (-a) == c);
             assert!(&a - (-b) == c);
             assert!((-c) - (-a) == (-b));
@@ -2812,7 +2812,7 @@ mod bigint_tests {
             assert!(c.checked_add(&(-b)).unwrap() == a);
             assert!(a.checked_add(&(-c)).unwrap() == (-b));
             assert!(b.checked_add(&(-c)).unwrap() == (-a));
-            assert!((-a).checked_add(&(-b)).unwrap() == (-c))
+            assert!((-a).checked_add(&(-b)).unwrap() == (-c));
             assert!(a.checked_add(&(-a)).unwrap() == Zero::zero());
         }
     }
@@ -2827,8 +2827,8 @@ mod bigint_tests {
 
             assert!(c.checked_sub(&a).unwrap() == b);
             assert!(c.checked_sub(&b).unwrap() == a);
-            assert!((-b).checked_sub(&a).unwrap() == (-c))
-            assert!((-a).checked_sub(&b).unwrap() == (-c))
+            assert!((-b).checked_sub(&a).unwrap() == (-c));
+            assert!((-a).checked_sub(&b).unwrap() == (-c));
             assert!(b.checked_sub(&(-a)).unwrap() == c);
             assert!(a.checked_sub(&(-b)).unwrap() == c);
             assert!((-c).checked_sub(&(-a)).unwrap() == (-b));

--- a/src/complex.rs
+++ b/src/complex.rs
@@ -137,14 +137,14 @@ macro_rules! forward_val_ref_binop {
 
 macro_rules! forward_all_binop {
     (impl $imp:ident, $method:ident) => {
-        forward_val_val_binop!(impl $imp, $method)
-        forward_ref_val_binop!(impl $imp, $method)
-        forward_val_ref_binop!(impl $imp, $method)
+        forward_val_val_binop!(impl $imp, $method);
+        forward_ref_val_binop!(impl $imp, $method);
+        forward_val_ref_binop!(impl $imp, $method);
     };
 }
 
 /* arithmetic */
-forward_all_binop!(impl Add, add)
+forward_all_binop!(impl Add, add);
 
 // (a + i b) + (c + i d) == (a + c) + i (b + d)
 impl<'a, 'b, T: Clone + Num> Add<&'b Complex<T>, Complex<T>> for &'a Complex<T> {
@@ -155,7 +155,7 @@ impl<'a, 'b, T: Clone + Num> Add<&'b Complex<T>, Complex<T>> for &'a Complex<T> 
     }
 }
 
-forward_all_binop!(impl Sub, sub)
+forward_all_binop!(impl Sub, sub);
 
 // (a + i b) - (c + i d) == (a - c) + i (b - d)
 impl<'a, 'b, T: Clone + Num> Sub<&'b Complex<T>, Complex<T>> for &'a Complex<T> {
@@ -166,7 +166,7 @@ impl<'a, 'b, T: Clone + Num> Sub<&'b Complex<T>, Complex<T>> for &'a Complex<T> 
     }
 }
 
-forward_all_binop!(impl Mul, mul)
+forward_all_binop!(impl Mul, mul);
 
 // (a + i b) * (c + i d) == (a*c - b*d) + i (a*d + b*c)
 impl<'a, 'b, T: Clone + Num> Mul<&'b Complex<T>, Complex<T>> for &'a Complex<T> {
@@ -177,7 +177,7 @@ impl<'a, 'b, T: Clone + Num> Mul<&'b Complex<T>, Complex<T>> for &'a Complex<T> 
     }
 }
 
-forward_all_binop!(impl Div, div)
+forward_all_binop!(impl Div, div);
 
 // (a + i b) / (c + i d) == [(a + i b) * (c - i d)] / (c*c + d*d)
 //   == [(a*c + b*d) / (c*c + d*d)] + i [(b*c - a*d) / (c*c + d*d)]

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -376,11 +376,11 @@ macro_rules! impl_integer_for_int {
     )
 }
 
-impl_integer_for_int!(i8,   test_integer_i8)
-impl_integer_for_int!(i16,  test_integer_i16)
-impl_integer_for_int!(i32,  test_integer_i32)
-impl_integer_for_int!(i64,  test_integer_i64)
-impl_integer_for_int!(int,  test_integer_int)
+impl_integer_for_int!(i8,   test_integer_i8);
+impl_integer_for_int!(i16,  test_integer_i16);
+impl_integer_for_int!(i32,  test_integer_i32);
+impl_integer_for_int!(i64,  test_integer_i64);
+impl_integer_for_int!(int,  test_integer_int);
 
 macro_rules! impl_integer_for_uint {
     ($T:ty, $test_mod:ident) => (
@@ -501,8 +501,8 @@ macro_rules! impl_integer_for_uint {
     )
 }
 
-impl_integer_for_uint!(u8,   test_integer_u8)
-impl_integer_for_uint!(u16,  test_integer_u16)
-impl_integer_for_uint!(u32,  test_integer_u32)
-impl_integer_for_uint!(u64,  test_integer_u64)
-impl_integer_for_uint!(uint, test_integer_uint)
+impl_integer_for_uint!(u8,   test_integer_u8);
+impl_integer_for_uint!(u16,  test_integer_u16);
+impl_integer_for_uint!(u32,  test_integer_u32);
+impl_integer_for_uint!(u64,  test_integer_u64);
+impl_integer_for_uint!(uint, test_integer_uint);

--- a/src/rational.rs
+++ b/src/rational.rs
@@ -211,7 +211,7 @@ impl Ratio<BigInt> {
 // "method name" (return value is bool in that case)
 macro_rules! cmp_impl {
     (impl $imp:ident, $($method:ident),+) => {
-        cmp_impl!(impl $imp, $($method -> bool),+)
+        cmp_impl!(impl $imp, $($method -> bool),+);
     };
     // return something other than a Ratio<T>
     (impl $imp:ident, $($method:ident -> $res:ty),*) => {
@@ -225,11 +225,11 @@ macro_rules! cmp_impl {
         }
     };
 }
-cmp_impl!(impl PartialEq, eq, ne)
+cmp_impl!(impl PartialEq, eq, ne);
 cmp_impl!(impl PartialOrd, lt -> bool, gt -> bool, le -> bool, ge -> bool,
-          partial_cmp -> Option<cmp::Ordering>)
-cmp_impl!(impl Eq, )
-cmp_impl!(impl Ord, cmp -> cmp::Ordering)
+          partial_cmp -> Option<cmp::Ordering>);
+cmp_impl!(impl Eq, );
+cmp_impl!(impl Ord, cmp -> cmp::Ordering);
 
 macro_rules! forward_val_val_binop {
     (impl $imp:ident, $method:ident) => {
@@ -266,14 +266,14 @@ macro_rules! forward_val_ref_binop {
 
 macro_rules! forward_all_binop {
     (impl $imp:ident, $method:ident) => {
-        forward_val_val_binop!(impl $imp, $method)
-        forward_ref_val_binop!(impl $imp, $method)
-        forward_val_ref_binop!(impl $imp, $method)
+        forward_val_val_binop!(impl $imp, $method);
+        forward_ref_val_binop!(impl $imp, $method);
+        forward_val_ref_binop!(impl $imp, $method);
     };
 }
 
 /* Arithmetic */
-forward_all_binop!(impl Mul, mul)
+forward_all_binop!(impl Mul, mul);
 // a/b * c/d = (a*c)/(b*d)
 impl<'a, 'b, T: Clone + Integer + PartialOrd>
     Mul<&'b Ratio<T>, Ratio<T>> for &'a Ratio<T> {
@@ -283,7 +283,7 @@ impl<'a, 'b, T: Clone + Integer + PartialOrd>
     }
 }
 
-forward_all_binop!(impl Div, div)
+forward_all_binop!(impl Div, div);
 // (a/b) / (c/d) = (a*d)/(b*c)
 impl<'a, 'b, T: Clone + Integer + PartialOrd>
     Div<&'b Ratio<T>, Ratio<T>> for &'a Ratio<T> {
@@ -296,7 +296,7 @@ impl<'a, 'b, T: Clone + Integer + PartialOrd>
 // Abstracts the a/b `op` c/d = (a*d `op` b*d) / (b*d) pattern
 macro_rules! arith_impl {
     (impl $imp:ident, $method:ident) => {
-        forward_all_binop!(impl $imp, $method)
+        forward_all_binop!(impl $imp, $method);
         impl<'a, 'b, T: Clone + Integer + PartialOrd>
             $imp<&'b Ratio<T>,Ratio<T>> for &'a Ratio<T> {
             #[inline]
@@ -309,13 +309,13 @@ macro_rules! arith_impl {
 }
 
 // a/b + c/d = (a*d + b*c)/(b*d)
-arith_impl!(impl Add, add)
+arith_impl!(impl Add, add);
 
 // a/b - c/d = (a*d - b*c)/(b*d)
-arith_impl!(impl Sub, sub)
+arith_impl!(impl Sub, sub);
 
 // a/b % c/d = (a*d % b*c)/(b*d)
-arith_impl!(impl Rem, rem)
+arith_impl!(impl Rem, rem);
 
 impl<T: Clone + Integer + PartialOrd>
     Neg<Ratio<T>> for Ratio<T> {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -24,13 +24,13 @@ pub trait Num: PartialEq + Zero + One
              + Div<Self,Self>
              + Rem<Self,Self> {}
 
-macro_rules! trait_impl(
+macro_rules! trait_impl {
     ($name:ident for $($t:ty)*) => ($(
         impl $name for $t {}
     )*)
-)
+}
 
-trait_impl!(Num for uint u8 u16 u32 u64 int i8 i16 i32 i64 f32 f64)
+trait_impl!(Num for uint u8 u16 u32 u64 int i8 i16 i32 i64 f32 f64);
 
 /// Defines an additive identity element for `Self`.
 ///
@@ -62,7 +62,7 @@ pub trait Zero: Add<Self, Self> {
     fn is_zero(&self) -> bool;
 }
 
-macro_rules! zero_impl(
+macro_rules! zero_impl {
     ($t:ty, $v:expr) => {
         impl Zero for $t {
             #[inline]
@@ -71,22 +71,22 @@ macro_rules! zero_impl(
             fn is_zero(&self) -> bool { *self == $v }
         }
     }
-)
+}
 
-zero_impl!(uint, 0u)
-zero_impl!(u8,   0u8)
-zero_impl!(u16,  0u16)
-zero_impl!(u32,  0u32)
-zero_impl!(u64,  0u64)
+zero_impl!(uint, 0u);
+zero_impl!(u8,   0u8);
+zero_impl!(u16,  0u16);
+zero_impl!(u32,  0u32);
+zero_impl!(u64,  0u64);
 
-zero_impl!(int, 0i)
-zero_impl!(i8,  0i8)
-zero_impl!(i16, 0i16)
-zero_impl!(i32, 0i32)
-zero_impl!(i64, 0i64)
+zero_impl!(int, 0i);
+zero_impl!(i8,  0i8);
+zero_impl!(i16, 0i16);
+zero_impl!(i32, 0i32);
+zero_impl!(i64, 0i64);
 
-zero_impl!(f32, 0.0f32)
-zero_impl!(f64, 0.0f64)
+zero_impl!(f32, 0.0f32);
+zero_impl!(f64, 0.0f64);
 
 /// Defines a multiplicative identity element for `Self`.
 pub trait One: Mul<Self, Self> {
@@ -108,29 +108,29 @@ pub trait One: Mul<Self, Self> {
     fn one() -> Self;
 }
 
-macro_rules! one_impl(
+macro_rules! one_impl {
     ($t:ty, $v:expr) => {
         impl One for $t {
             #[inline]
             fn one() -> $t { $v }
         }
     }
-)
+}
 
-one_impl!(uint, 1u)
-one_impl!(u8,  1u8)
-one_impl!(u16, 1u16)
-one_impl!(u32, 1u32)
-one_impl!(u64, 1u64)
+one_impl!(uint, 1u);
+one_impl!(u8,  1u8);
+one_impl!(u16, 1u16);
+one_impl!(u32, 1u32);
+one_impl!(u64, 1u64);
 
-one_impl!(int, 1i)
-one_impl!(i8,  1i8)
-one_impl!(i16, 1i16)
-one_impl!(i32, 1i32)
-one_impl!(i64, 1i64)
+one_impl!(int, 1i);
+one_impl!(i8,  1i8);
+one_impl!(i16, 1i16);
+one_impl!(i32, 1i32);
+one_impl!(i64, 1i64);
 
-one_impl!(f32, 1.0f32)
-one_impl!(f64, 1.0f64)
+one_impl!(f32, 1.0f32);
+one_impl!(f64, 1.0f64);
 
 /// Useful functions for signed numbers (i.e. numbers that can be negative).
 pub trait Signed: Num + Neg<Self> {
@@ -169,7 +169,7 @@ pub trait Signed: Num + Neg<Self> {
     fn is_negative(&self) -> bool;
 }
 
-macro_rules! signed_impl(
+macro_rules! signed_impl {
     ($($t:ty)*) => ($(
         impl Signed for $t {
             #[inline]
@@ -198,11 +198,11 @@ macro_rules! signed_impl(
             fn is_negative(&self) -> bool { *self < 0 }
         }
     )*)
-)
+}
 
-signed_impl!(int i8 i16 i32 i64)
+signed_impl!(int i8 i16 i32 i64);
 
-macro_rules! signed_float_impl(
+macro_rules! signed_float_impl {
     ($t:ty, $nan:expr, $inf:expr, $neg_inf:expr, $fabs:path, $fcopysign:path, $fdim:ident) => {
         impl Signed for $t {
             /// Computes the absolute value. Returns `NAN` if the number is `NAN`.
@@ -241,17 +241,17 @@ macro_rules! signed_float_impl(
             fn is_negative(&self) -> bool { *self < 0.0 || (1.0 / *self) == $neg_inf }
         }
     }
-)
+}
 
 signed_float_impl!(f32, f32::NAN, f32::INFINITY, f32::NEG_INFINITY,
-                   intrinsics::fabsf32, intrinsics::copysignf32, fdimf)
+                   intrinsics::fabsf32, intrinsics::copysignf32, fdimf);
 signed_float_impl!(f64, f64::NAN, f64::INFINITY, f64::NEG_INFINITY,
-                   intrinsics::fabsf64, intrinsics::copysignf64, fdim)
+                   intrinsics::fabsf64, intrinsics::copysignf64, fdim);
 
 /// A trait for values which cannot be negative
 pub trait Unsigned: Num {}
 
-trait_impl!(Unsigned for uint u8 u16 u32 u64)
+trait_impl!(Unsigned for uint u8 u16 u32 u64);
 
 /// Numbers which have upper and lower bounds
 pub trait Bounded {
@@ -262,7 +262,7 @@ pub trait Bounded {
     fn max_value() -> Self;
 }
 
-macro_rules! bounded_impl(
+macro_rules! bounded_impl {
     ($t:ty, $min:expr, $max:expr) => {
         impl Bounded for $t {
             #[inline]
@@ -272,22 +272,22 @@ macro_rules! bounded_impl(
             fn max_value() -> $t { $max }
         }
     }
-)
+}
 
-bounded_impl!(uint, uint::MIN, uint::MAX)
-bounded_impl!(u8, u8::MIN, u8::MAX)
-bounded_impl!(u16, u16::MIN, u16::MAX)
-bounded_impl!(u32, u32::MIN, u32::MAX)
-bounded_impl!(u64, u64::MIN, u64::MAX)
+bounded_impl!(uint, uint::MIN, uint::MAX);
+bounded_impl!(u8, u8::MIN, u8::MAX);
+bounded_impl!(u16, u16::MIN, u16::MAX);
+bounded_impl!(u32, u32::MIN, u32::MAX);
+bounded_impl!(u64, u64::MIN, u64::MAX);
 
-bounded_impl!(int, int::MIN, int::MAX)
-bounded_impl!(i8, i8::MIN, i8::MAX)
-bounded_impl!(i16, i16::MIN, i16::MAX)
-bounded_impl!(i32, i32::MIN, i32::MAX)
-bounded_impl!(i64, i64::MIN, i64::MAX)
+bounded_impl!(int, int::MIN, int::MAX);
+bounded_impl!(i8, i8::MIN, i8::MAX);
+bounded_impl!(i16, i16::MIN, i16::MAX);
+bounded_impl!(i32, i32::MIN, i32::MAX);
+bounded_impl!(i64, i64::MIN, i64::MAX);
 
-bounded_impl!(f32, f32::MIN_VALUE, f32::MAX_VALUE)
-bounded_impl!(f64, f64::MIN_VALUE, f64::MAX_VALUE)
+bounded_impl!(f32, f32::MIN_VALUE, f32::MAX_VALUE);
+bounded_impl!(f64, f64::MIN_VALUE, f64::MAX_VALUE);
 
 /// Saturating math operations
 pub trait Saturating {
@@ -340,7 +340,7 @@ pub trait CheckedAdd: Add<Self, Self> {
     fn checked_add(&self, v: &Self) -> Option<Self>;
 }
 
-macro_rules! checked_impl(
+macro_rules! checked_impl {
     ($trait_name:ident, $method:ident, $t:ty, $op:path) => {
         impl $trait_name for $t {
             #[inline]
@@ -352,8 +352,8 @@ macro_rules! checked_impl(
             }
         }
     }
-)
-macro_rules! checked_cast_impl(
+}
+macro_rules! checked_cast_impl {
     ($trait_name:ident, $method:ident, $t:ty, $cast:ty, $op:path) => {
         impl $trait_name for $t {
             #[inline]
@@ -365,27 +365,27 @@ macro_rules! checked_cast_impl(
             }
         }
     }
-)
+}
 
 #[cfg(target_word_size = "32")]
-checked_cast_impl!(CheckedAdd, checked_add, uint, u32, intrinsics::u32_add_with_overflow)
+checked_cast_impl!(CheckedAdd, checked_add, uint, u32, intrinsics::u32_add_with_overflow);
 #[cfg(target_word_size = "64")]
-checked_cast_impl!(CheckedAdd, checked_add, uint, u64, intrinsics::u64_add_with_overflow)
+checked_cast_impl!(CheckedAdd, checked_add, uint, u64, intrinsics::u64_add_with_overflow);
 
-checked_impl!(CheckedAdd, checked_add, u8,  intrinsics::u8_add_with_overflow)
-checked_impl!(CheckedAdd, checked_add, u16, intrinsics::u16_add_with_overflow)
-checked_impl!(CheckedAdd, checked_add, u32, intrinsics::u32_add_with_overflow)
-checked_impl!(CheckedAdd, checked_add, u64, intrinsics::u64_add_with_overflow)
+checked_impl!(CheckedAdd, checked_add, u8,  intrinsics::u8_add_with_overflow);
+checked_impl!(CheckedAdd, checked_add, u16, intrinsics::u16_add_with_overflow);
+checked_impl!(CheckedAdd, checked_add, u32, intrinsics::u32_add_with_overflow);
+checked_impl!(CheckedAdd, checked_add, u64, intrinsics::u64_add_with_overflow);
 
 #[cfg(target_word_size = "32")]
-checked_cast_impl!(CheckedAdd, checked_add, int, i32, intrinsics::i32_add_with_overflow)
+checked_cast_impl!(CheckedAdd, checked_add, int, i32, intrinsics::i32_add_with_overflow);
 #[cfg(target_word_size = "64")]
-checked_cast_impl!(CheckedAdd, checked_add, int, i64, intrinsics::i64_add_with_overflow)
+checked_cast_impl!(CheckedAdd, checked_add, int, i64, intrinsics::i64_add_with_overflow);
 
-checked_impl!(CheckedAdd, checked_add, i8,  intrinsics::i8_add_with_overflow)
-checked_impl!(CheckedAdd, checked_add, i16, intrinsics::i16_add_with_overflow)
-checked_impl!(CheckedAdd, checked_add, i32, intrinsics::i32_add_with_overflow)
-checked_impl!(CheckedAdd, checked_add, i64, intrinsics::i64_add_with_overflow)
+checked_impl!(CheckedAdd, checked_add, i8,  intrinsics::i8_add_with_overflow);
+checked_impl!(CheckedAdd, checked_add, i16, intrinsics::i16_add_with_overflow);
+checked_impl!(CheckedAdd, checked_add, i32, intrinsics::i32_add_with_overflow);
+checked_impl!(CheckedAdd, checked_add, i64, intrinsics::i64_add_with_overflow);
 
 /// Performs subtraction that returns `None` instead of wrapping around on underflow.
 pub trait CheckedSub: Sub<Self, Self> {
@@ -402,24 +402,24 @@ pub trait CheckedSub: Sub<Self, Self> {
 }
 
 #[cfg(target_word_size = "32")]
-checked_cast_impl!(CheckedSub, checked_sub, uint, u32, intrinsics::u32_sub_with_overflow)
+checked_cast_impl!(CheckedSub, checked_sub, uint, u32, intrinsics::u32_sub_with_overflow);
 #[cfg(target_word_size = "64")]
-checked_cast_impl!(CheckedSub, checked_sub, uint, u64, intrinsics::u64_sub_with_overflow)
+checked_cast_impl!(CheckedSub, checked_sub, uint, u64, intrinsics::u64_sub_with_overflow);
 
-checked_impl!(CheckedSub, checked_sub, u8,  intrinsics::u8_sub_with_overflow)
-checked_impl!(CheckedSub, checked_sub, u16, intrinsics::u16_sub_with_overflow)
-checked_impl!(CheckedSub, checked_sub, u32, intrinsics::u32_sub_with_overflow)
-checked_impl!(CheckedSub, checked_sub, u64, intrinsics::u64_sub_with_overflow)
+checked_impl!(CheckedSub, checked_sub, u8,  intrinsics::u8_sub_with_overflow);
+checked_impl!(CheckedSub, checked_sub, u16, intrinsics::u16_sub_with_overflow);
+checked_impl!(CheckedSub, checked_sub, u32, intrinsics::u32_sub_with_overflow);
+checked_impl!(CheckedSub, checked_sub, u64, intrinsics::u64_sub_with_overflow);
 
 #[cfg(target_word_size = "32")]
-checked_cast_impl!(CheckedSub, checked_sub, int, i32, intrinsics::i32_sub_with_overflow)
+checked_cast_impl!(CheckedSub, checked_sub, int, i32, intrinsics::i32_sub_with_overflow);
 #[cfg(target_word_size = "64")]
-checked_cast_impl!(CheckedSub, checked_sub, int, i64, intrinsics::i64_sub_with_overflow)
+checked_cast_impl!(CheckedSub, checked_sub, int, i64, intrinsics::i64_sub_with_overflow);
 
-checked_impl!(CheckedSub, checked_sub, i8,  intrinsics::i8_sub_with_overflow)
-checked_impl!(CheckedSub, checked_sub, i16, intrinsics::i16_sub_with_overflow)
-checked_impl!(CheckedSub, checked_sub, i32, intrinsics::i32_sub_with_overflow)
-checked_impl!(CheckedSub, checked_sub, i64, intrinsics::i64_sub_with_overflow)
+checked_impl!(CheckedSub, checked_sub, i8,  intrinsics::i8_sub_with_overflow);
+checked_impl!(CheckedSub, checked_sub, i16, intrinsics::i16_sub_with_overflow);
+checked_impl!(CheckedSub, checked_sub, i32, intrinsics::i32_sub_with_overflow);
+checked_impl!(CheckedSub, checked_sub, i64, intrinsics::i64_sub_with_overflow);
 
 /// Performs multiplication that returns `None` instead of wrapping around on underflow or
 /// overflow.
@@ -438,24 +438,24 @@ pub trait CheckedMul: Mul<Self, Self> {
 }
 
 #[cfg(target_word_size = "32")]
-checked_cast_impl!(CheckedMul, checked_mul, uint, u32, intrinsics::u32_mul_with_overflow)
+checked_cast_impl!(CheckedMul, checked_mul, uint, u32, intrinsics::u32_mul_with_overflow);
 #[cfg(target_word_size = "64")]
-checked_cast_impl!(CheckedMul, checked_mul, uint, u64, intrinsics::u64_mul_with_overflow)
+checked_cast_impl!(CheckedMul, checked_mul, uint, u64, intrinsics::u64_mul_with_overflow);
 
-checked_impl!(CheckedMul, checked_mul, u8,  intrinsics::u8_mul_with_overflow)
-checked_impl!(CheckedMul, checked_mul, u16, intrinsics::u16_mul_with_overflow)
-checked_impl!(CheckedMul, checked_mul, u32, intrinsics::u32_mul_with_overflow)
-checked_impl!(CheckedMul, checked_mul, u64, intrinsics::u64_mul_with_overflow)
+checked_impl!(CheckedMul, checked_mul, u8,  intrinsics::u8_mul_with_overflow);
+checked_impl!(CheckedMul, checked_mul, u16, intrinsics::u16_mul_with_overflow);
+checked_impl!(CheckedMul, checked_mul, u32, intrinsics::u32_mul_with_overflow);
+checked_impl!(CheckedMul, checked_mul, u64, intrinsics::u64_mul_with_overflow);
 
 #[cfg(target_word_size = "32")]
-checked_cast_impl!(CheckedMul, checked_mul, int, i32, intrinsics::i32_mul_with_overflow)
+checked_cast_impl!(CheckedMul, checked_mul, int, i32, intrinsics::i32_mul_with_overflow);
 #[cfg(target_word_size = "64")]
-checked_cast_impl!(CheckedMul, checked_mul, int, i64, intrinsics::i64_mul_with_overflow)
+checked_cast_impl!(CheckedMul, checked_mul, int, i64, intrinsics::i64_mul_with_overflow);
 
-checked_impl!(CheckedMul, checked_mul, i8,  intrinsics::i8_mul_with_overflow)
-checked_impl!(CheckedMul, checked_mul, i16, intrinsics::i16_mul_with_overflow)
-checked_impl!(CheckedMul, checked_mul, i32, intrinsics::i32_mul_with_overflow)
-checked_impl!(CheckedMul, checked_mul, i64, intrinsics::i64_mul_with_overflow)
+checked_impl!(CheckedMul, checked_mul, i8,  intrinsics::i8_mul_with_overflow);
+checked_impl!(CheckedMul, checked_mul, i16, intrinsics::i16_mul_with_overflow);
+checked_impl!(CheckedMul, checked_mul, i32, intrinsics::i32_mul_with_overflow);
+checked_impl!(CheckedMul, checked_mul, i64, intrinsics::i64_mul_with_overflow);
 
 /// Performs division that returns `None` instead of panicking on division by zero and instead of
 /// wrapping around on underflow and overflow.
@@ -474,7 +474,7 @@ pub trait CheckedDiv: Div<Self, Self> {
     fn checked_div(&self, v: &Self) -> Option<Self>;
 }
 
-macro_rules! checkeddiv_int_impl(
+macro_rules! checkeddiv_int_impl {
     ($t:ty, $min:expr) => {
         impl CheckedDiv for $t {
             #[inline]
@@ -487,15 +487,15 @@ macro_rules! checkeddiv_int_impl(
             }
         }
     }
-)
+}
 
-checkeddiv_int_impl!(int, int::MIN)
-checkeddiv_int_impl!(i8, i8::MIN)
-checkeddiv_int_impl!(i16, i16::MIN)
-checkeddiv_int_impl!(i32, i32::MIN)
-checkeddiv_int_impl!(i64, i64::MIN)
+checkeddiv_int_impl!(int, int::MIN);
+checkeddiv_int_impl!(i8, i8::MIN);
+checkeddiv_int_impl!(i16, i16::MIN);
+checkeddiv_int_impl!(i32, i32::MIN);
+checkeddiv_int_impl!(i64, i64::MIN);
 
-macro_rules! checkeddiv_uint_impl(
+macro_rules! checkeddiv_uint_impl {
     ($($t:ty)*) => ($(
         impl CheckedDiv for $t {
             #[inline]
@@ -508,7 +508,7 @@ macro_rules! checkeddiv_uint_impl(
             }
         }
     )*)
-)
+}
 
-checkeddiv_uint_impl!(uint u8 u16 u32 u64)
+checkeddiv_uint_impl!(uint u8 u16 u32 u64);
 


### PR DESCRIPTION
Fixes compile errors introduced by PR [#19984](https://github.com/rust-lang/rust/pull/19984).

Example: 
error: macros that expand to items must either be surrounded with braces or followed by a semicolon
