### PR TITLE
Implement Stein's algorithm for gcd

### DIFF
--- a/src/integer.rs
+++ b/src/integer.rs
@@ -360,6 +360,47 @@ macro_rules! impl_integer_for_isize {
                 assert_eq!((-6 as $T).gcd(&3), 3 as $T);
                 assert_eq!((-4 as $T).gcd(&-2), 2 as $T);
             }
+            #[test]
+            fn test_gcd_cmp_with_euclidean() {
+                fn euclidean_gcd(mut m: $T, mut n: $T) -> $T {
+                    while m != 0 {
+                        ::std::mem::swap(&mut m, &mut n);
+                        m %= n;
+                    }
+
+                    n.abs()
+                }
+
+                // gcd(-128, b) = 128 is not representable as positive value
+                // for i8
+                for i in -127..127 {
+                    for j in -127..127 {
+                        assert_eq!(euclidean_gcd(i,j), i.gcd(&j));
+                    }
+                }
+
+                // last value
+                // FIXME: Use inclusive ranges for above loop when implemented
+                let i = 127;
+                for j in -127..127 {
+                    assert_eq!(euclidean_gcd(i,j), i.gcd(&j));
+                }
+                assert_eq!(127.gcd(&127), 127);
+            }
+
+            #[test]
+            #[should_panic]
+            fn test_gcd_min_val_min_val() {
+                let min = <$T>::min_value();
+                min.gcd(&min);
+            }
+
+            #[test]
+            #[should_panic]
+            fn test_gcd_min_val_0() {
+                let min = <$T>::min_value();
+                min.gcd(&0);
+            }
 
             #[test]
             fn test_lcm() {
@@ -496,6 +537,31 @@ macro_rules! impl_integer_for_usize {
                 assert_eq!((0 as $T).gcd(&3), 3 as $T);
                 assert_eq!((3 as $T).gcd(&3), 3 as $T);
                 assert_eq!((56 as $T).gcd(&42), 14 as $T);
+            }
+
+            #[test]
+            fn test_gcd_cmp_with_euclidean() {
+                fn euclidean_gcd(mut m: $T, mut n: $T) -> $T {
+                    while m != 0 {
+                        ::std::mem::swap(&mut m, &mut n);
+                        m %= n;
+                    }
+                    n
+                }
+
+                for i in 0..255 {
+                    for j in 0..255 {
+                        assert_eq!(euclidean_gcd(i,j), i.gcd(&j));
+                    }
+                }
+
+                // last value
+                // FIXME: Use inclusive ranges for above loop when implemented
+                let i = 255;
+                for j in 0..255 {
+                    assert_eq!(euclidean_gcd(i,j), i.gcd(&j));
+                }
+                assert_eq!(255.gcd(&255), 255);
             }
 
             #[test]

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -230,7 +230,7 @@ macro_rules! impl_integer_for_isize {
                 // trivially be calculated in that case by bitshifting
 
                 // The result is always positive in two's complement, unless
-                // a and b are the minimum value, then it's negative
+                // n and m are the minimum value, then it's negative
                 // no other way to represent that number
                 if m == <$T>::min_value() || n == <$T>::min_value() { return 1 << shift }
 
@@ -238,7 +238,7 @@ macro_rules! impl_integer_for_isize {
                 m = m.abs();
                 n = n.abs();
 
-                // divide a and b by 2 until odd
+                // divide n and m by 2 until odd
                 // m inside loop
                 n >>= n.trailing_zeros();
 
@@ -427,7 +427,7 @@ macro_rules! impl_integer_for_usize {
                 // find common factors of 2
                 let shift = (m | n).trailing_zeros();
 
-                // divide a and b by 2 until odd
+                // divide n and m by 2 until odd
                 // m inside loop
                 n >>= n.trailing_zeros();
 

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -225,14 +225,17 @@ macro_rules! impl_integer_for_isize {
                 // find common factors of 2
                 let shift = (m | n).trailing_zeros();
 
-                // If one number is the minimum value, it cannot be represented as a
-                // positive number. It's also a power of two, so the gcd can
-                // trivially be calculated in that case by bitshifting
+                // The algorithm needs positive numbers, but the minimum value
+                // can't be represented as a positive one.
+                // It's also a power of two, so the gcd can be
+                // calculated by bitshifting in that case
 
-                // The result is always positive in two's complement, unless
-                // n and m are the minimum value, then it's negative
-                // no other way to represent that number
-                if m == <$T>::min_value() || n == <$T>::min_value() { return 1 << shift }
+                // Assuming two's complement, the number created by the shift
+                // is positive for all numbers except gcd = abs(min value)
+                // The call to .abs() causes a panic in debug mode
+                if m == <$T>::min_value() || n == <$T>::min_value() {
+                    return (1 << shift).abs()
+                }
 
                 // guaranteed to be positive now, rest like unsigned algorithm
                 m = m.abs();


### PR DESCRIPTION
The binary gcd algorithm offers significant speedups when the CPU has a builtin instruction for counting trailing zeros.

I benched the improvements with random numbers. Code is at  https://github.com/Emerentius/gcd_bench . These are only rough measurements, I used 50 (Edit: Now 5000) number pairs for each. The old gcd liked to crash for `i8` when I used more.

These are the improvements on my machine (Intel i5 2500k). All numbers are averaged.

```
u8
gcd:            29.65 ns / call
binary_gcd:     20.70 ns / call (  43.2% faster )

u16
gcd:            58.66 ns / call
binary_gcd:     42.50 ns / call (  38.0% faster )

u32
gcd:            96.71 ns / call
binary_gcd:     72.13 ns / call (  34.1% faster )

u64
gcd:           314.31 ns / call
binary_gcd:    148.77 ns / call ( 111.3% faster )

i8
gcd:            28.31 ns / call
binary_gcd:     17.33 ns / call (  63.3% faster )

i16
gcd:            62.20 ns / call
binary_gcd:     37.74 ns / call (  64.8% faster )

i32
gcd:           102.19 ns / call
binary_gcd:     65.84 ns / call (  55.2% faster )

i64
gcd:           388.04 ns / call
binary_gcd:    136.96 ns / call ( 183.3% faster )
```

As a bonus: `i8::min_value() % -1` and variants panic in the implementation of the euclidean algorithm. This implementation doesn't panic. Like in the euclidean implementation, the special case `gcd(i8::min_value(), i8::min_value()) == i8::min_value()` (negative output) still exists. Edit: In Debug mode it now panics.

I'm relying on signed integers to be in two's complement form.

Edit: 
* Updated bench numbers with 5000 random numbers for better statistics
* Added mention of debug mode panics on minimum value