### PR TITLE
Add bit manipulation algorithms to PrimInt

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1355,16 +1355,12 @@ macro_rules! prim_int_impl {
 
             fn bits_to_unsigned(self) -> $AU
             {
-                unsafe {
-                    mem::transmute::<$T, $AU>(self)
-                }
+                self as $AU
             }
 
             fn bits_to_signed(self) -> $AS
             {
-                unsafe {
-                    mem::transmute::<$T, $AS>(self)
-                }
+                self as $AS
             }
             
             fn count_ones(self) -> u32 {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -701,7 +701,7 @@ pub trait PrimInt
     /// ```
     /// use num::traits::PrimInt;
     ///
-    /// let n = 0b0100_1100u8;
+    /// let n = 0b01001100u8;
     ///
     /// assert_eq!(n.count_ones(), 3);
     /// ```
@@ -714,7 +714,7 @@ pub trait PrimInt
     /// ```
     /// use num::traits::PrimInt;
     ///
-    /// let n = 0b0100_1100u8;
+    /// let n = 0b01001100u8;
     ///
     /// assert_eq!(n.count_zeros(), 5);
     /// ```
@@ -728,7 +728,7 @@ pub trait PrimInt
     /// ```
     /// use num::traits::PrimInt;
     ///
-    /// let n = 0b0000_0000_0010_1000u16;
+    /// let n = 0b00101000u16;
     ///
     /// assert_eq!(n.leading_zeros(), 10);
     /// ```
@@ -742,7 +742,7 @@ pub trait PrimInt
     /// ```
     /// use num::traits::PrimInt;
     ///
-    /// let n = 0b0000_0000_0010_1000u16;
+    /// let n = 0b00101000u16;
     ///
     /// assert_eq!(n.trailing_zeros(), 3);
     /// ```
@@ -903,7 +903,7 @@ pub trait PrimInt
     /// ```
     /// use num::traits::PrimInt;
     ///
-    /// let n = 0b0000_0000_0010_0111u16;
+    /// let n = 0b0010_0111u16;
     ///
     /// assert_eq!(n.trailing_ones(), 3);
     /// ```
@@ -1095,9 +1095,9 @@ pub trait PrimInt
    /// let n = 0b0101_1111u8;
    /// let s = 0b0011_1111u8;  
    ///
-   /// assert_eq!(n.mask_trailing_zeros_and_least_significant_zero(), s);
+   /// assert_eq!(n.mask_trailing_ones_and_least_significant_zero(), s);
    /// ```
-   fn mask_trailing_zeros_and_least_significant_zero(self) -> Self {
+   fn mask_trailing_ones_and_least_significant_zero(self) -> Self {
        self ^ (self + cast(1).unwrap())
    }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -911,501 +911,754 @@ pub trait PrimInt
        Self::trailing_zeros(!self)
     }
 
-   /// Returns the number of 1 bits in `self` mod 2, that is, returns 1 if the number
-   /// of 1 bits in `self` is odd, and zero otherwise
-   ///
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n0 = 0b0000;  // 0 -> even => parity = 0
-   /// let n1 = 0b0001;  // 1 -> odd  => partiy = 1
-   /// let n2 = 0b0010;  // 1 -> odd  => parity = 1
-   /// let n3 = 0b0011;  // 2 -> even => parity = 0
-   ///
-   /// assert_eq!(n0.parity(), 0);
-   /// assert_eq!(n1.parity(), 1);
-   /// assert_eq!(n2.parity(), 1);
-   /// assert_eq!(n3.parity(), 0);
-   /// ```
-   fn parity(self) -> u32 {
-        // TODO: use intrinsics depending on size:
-        //  - __builtin_parity, __builtin_parityl, __builtin_parityll
-        self.count_ones() & 1
-   }
+    /// Returns the number of 1 bits in `self` mod 2, that is, returns 1 if the number
+    /// of 1 bits in `self` is odd, and zero otherwise
+    ///
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n0 = 0b0000;  // 0 -> even => parity = 0
+    /// let n1 = 0b0001;  // 1 -> odd  => partiy = 1
+    /// let n2 = 0b0010;  // 1 -> odd  => parity = 1
+    /// let n3 = 0b0011;  // 2 -> even => parity = 0
+    ///
+    /// assert_eq!(n0.parity(), 0);
+    /// assert_eq!(n1.parity(), 1);
+    /// assert_eq!(n2.parity(), 1);
+    /// assert_eq!(n3.parity(), 0);
+    /// ```
+    fn parity(self) -> u32 {
+         // TODO: use intrinsics depending on size:
+         //  - __builtin_parity, __builtin_parityl, __builtin_parityll
+         self.count_ones() & 1
+    }
+ 
+    /// Reset least significant 1 bit of `self`; returns 0 if `self` is 0.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b0110;
+    /// let s = 0b0100;  
+    ///
+    /// assert_eq!(n.reset_least_significant_one(), s);
+    /// ```
+    fn reset_least_significant_one(self) -> Self {
+        self & (self - <Self as One>::one())
+    }
+ 
+    /// Set least significant 0 bit of `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b0101;
+    /// let s = 0b0111;  
+    ///
+    /// assert_eq!(n.set_least_significant_zero(), s);
+    /// ```
+    fn set_least_significant_zero(self) -> Self {
+        self | (self + <Self as One>::one())
+    }
+ 
+    /// Isolate least significant 1 bit of `self` and returns it; returns 0
+    /// if `self` is 0.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b0110;
+    /// let s = 0b0010;  
+    ///
+    /// assert_eq!(n.isolate_least_significant_one(), s);
+    /// ```
+    fn isolate_least_significant_one(self) -> Self {
+        // note: self & -self is intended, which is rewritten as
+        // self & (0 - self), so:
+        self & (<Self as Zero>::zero() - self)
+    }
+ 
+    /// Set the least significant zero bit of `self` to 1 and all of the
+    /// rest to 0.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b0101;
+    /// let s = 0b0010;  
+    ///
+    /// assert_eq!(n.isolate_least_significant_zero(), s);
+    /// ```
+    fn isolate_least_significant_zero(self) -> Self {
+        (!self) & (self + <Self as One>::one())
+    }
+ 
+    /// Reset the trailing 1's in `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b0110_1111;
+    /// let s = 0b0110_0000;  
+    ///
+    /// assert_eq!(n.reset_trailing_ones(), s);
+    /// ```
+    fn reset_trailing_ones(self) -> Self {
+        self & (self + <Self as One>::one())
+    }
+ 
+    /// Set all of the trailing 0's in `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b0110_0000u8;
+    /// let s = 0b0111_1111u8;  
+    ///
+    /// assert_eq!(n.set_trailing_zeros(), s);
+    /// ```
+    fn set_trailing_zeros(self) -> Self {
+        self | (self - <Self as One>::one())
+    }
+ 
+    /// Returns a mask with all of the trailing 0's of `self` set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b0110_0000u8;
+    /// let s = 0b0001_1111u8;  
+    ///
+    /// assert_eq!(n.mask_trailing_zeros(), s);
+    /// ```
+    fn mask_trailing_zeros(self) -> Self {
+        (!self) & (self - <Self as One>::one())
+    }
+ 
+    /// Returns a mask with all of the trailing 1's of `self` set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b0101_1111u8;
+    /// let s = 0b0001_1111u8;  
+    ///
+    /// assert_eq!(n.mask_trailing_ones(), s);
+    /// ```
+    fn mask_trailing_ones(self) -> Self {
+        !((!self) | (self + <Self as One>::one()))
+    }
+    
+    /// Returns a mask with all of the trailing 0's of `self` set and the least
+    /// significant 1 bit set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b0101_0000u8;
+    /// let s = 0b0001_1111u8;  
+    ///
+    /// assert_eq!(n.mask_trailing_zeros_and_least_significant_one(), s);
+    /// ```
+    fn mask_trailing_zeros_and_least_significant_one(self) -> Self {
+        (self - <Self as One>::one()) ^ self
+    }
+ 
+    /// Returns a mask with all of the trailing 1's of `self` set and the least
+    /// significant 0 bit set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b0101_1111u8;
+    /// let s = 0b0011_1111u8;  
+    ///
+    /// assert_eq!(n.mask_trailing_ones_and_least_significant_zero(), s);
+    /// ```
+    fn mask_trailing_ones_and_least_significant_zero(self) -> Self {
+        self ^ (self + <Self as One>::one())
+    }
+ 
+    /// Reverses the bits of `self` by `subword_bits` and `group_subwords`:
+    ///
+    /// - `subword_bits`: the bits will be reversed in grous:
+    ///   1 (single bits), 2 (pair-wise), 4 (nibbles)
+    /// - `group_subwords`: the subword size is 8 bits: `mem::size_of::<u8>()`,
+    ///   the bits will be reversed within each subword.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b0101_1101_1010_0101_u16;
+    ///
+    /// // Single bits:
+    /// let s0 = 0b1010_0101_1011_1010u16;
+    /// assert_eq!(n.reverse_bit_groups(1, 1), s0);
+    ///
+    /// // Bit pairs:
+    /// let s1 = 0b0101_1010_0111_0101u16;
+    /// assert_eq!(n.reverse_bit_groups(2, 1), s1);
+    ///
+    /// // Bit nibbles:
+    /// let s2 = 0b0101_1010_1101_0101u16;
+    /// assert_eq!(n.reverse_bit_groups(4, 1), s2);
+    ///
+    /// // Single bits: group_subwords = 2
+    /// let s3 = 0b1011_1010_1010_0101u16;
+    /// assert_eq!(n.reverse_bit_groups(1, 2), s3);
+    ///
+    /// // Bit pairs: group_subwords = 2
+    /// let s4 = 0b0111_0101_0101_1010u16;
+    /// assert_eq!(n.reverse_bit_groups(2, 2), s4);
+    ///
+    /// // Bit nibbles: group_subwords = 2
+    /// let s5 = 0b1101_0101_0101_1010u16;
+    /// assert_eq!(n.reverse_bit_groups(4, 2), s5);
+    /// ```
+    fn reverse_bit_groups(self, subword_bits: u32, group_subwords: u32) -> Self;
+ 
+    /// Reverses the bits of `self`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b1011_0010u8;
+    /// let s = 0b0100_1101u8;  
+    /// assert_eq!(n.reverse_bits(), s);
+    ///
+    /// let n1 = 0b1011_0010_1010_1001u16;
+    /// let s1 = 0b1001_0101_0100_1101u16;
+    /// assert_eq!(n1.reverse_bits(), s1);
+    /// ```
+    fn reverse_bits(self) -> Self {
+        self.reverse_bit_groups(1, 1)
+    }
+ 
+    /// Reverses the pairs of bits of `self`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b1011_0010u8;
+    /// let s = 0b1000_1110u8;  
+    /// assert_eq!(n.reverse_bit_pairs(), s);
+    ///
+    /// let n1 = 0b1011_0010_1010_1001u16;
+    /// let s1 = 0b0110_1010_1000_1110u16;
+    /// assert_eq!(n1.reverse_bit_pairs(), s1);
+    /// ```
+    fn reverse_bit_pairs(self) -> Self {
+        self.reverse_bit_groups(2, 1)
+    }
+ 
+    /// Reverses the nibbles of `self`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b1011_0010u8;
+    /// let s = 0b0010_1011u8;  
+    /// assert_eq!(n.reverse_bit_nibbles(), s);
+    ///
+    /// let n1 = 0b1011_0010_1010_1001u16;
+    /// let s1 = 0b1001_1010_0010_1011u16;
+    /// assert_eq!(n1.reverse_bit_nibbles(), s1);
+    /// ```
+    fn reverse_bit_nibbles(self) -> Self {
+        self.reverse_bit_groups(4, 1)
+    }
+ 
+    /// Reverses the bytes of `self`
+    ///
+    /// - `bytes_per_block`: number of bytes per block to reverse.
+    /// - `blocks_per_group`: number of blocks per group of blocks.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b0101_1101_1010_0101_u16;
+    ///
+    /// // Single bytes:
+    /// let s0 = 0b1010_0101_0101_1101u16;
+    /// assert_eq!(n.reverse_byte_groups(1, 1), s0);
+    ///
+    /// // Single bytes: group_subwords = 2
+    /// let s3 = 0b0101_1101_1010_0101u16;
+    /// assert_eq!(n.reverse_byte_groups(1, 2), s3);
+    /// ```
+    fn reverse_byte_groups(self, bytes_per_block: u32, blocks_per_group: u32) -> Self {
+        self.reverse_bit_groups(8 * bytes_per_block, blocks_per_group)
+    }
+ 
+    /// Reverses the bytes of `self` (equivalent to swap bytes)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b1011_0010u8;
+    /// let s = 0b1011_0010u8;  
+    /// assert_eq!(n.reverse_bytes(), s);
+    /// assert_eq!(n.swap_bytes(), s);
+    ///
+    /// let n1 = 0b1011_0010_1010_1001u16;
+    /// let s1 = 0b1010_1001_1011_0010u16;
+    /// assert_eq!(n1.reverse_bytes(), s1);
+    /// assert_eq!(n1.swap_bytes(), s1);
+    /// ```
+    fn reverse_bytes(self) -> Self {
+        self.swap_bytes()
+    }
+ 
+    /// Sets the `bit` of `self`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n  = 0b1011_0010u8;
+    /// let s0 = 0b1111_0010u8;
+    /// let s1 = 0b1011_0011u8;
+    /// let s2 = 0b1011_1010u8;  
+    /// assert_eq!(n.set_bit(6), s0);
+    /// assert_eq!(n.set_bit(0), s1);
+    /// assert_eq!(n.set_bit(3), s2);
+    /// ```
+    fn set_bit(self, bit: u32) -> Self {
+         self | (<Self as One>::one() << bit)
+    }
+ 
+    /// Resets the `bit` of `self`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b1011_0010u8;
+    /// let s0 = 0b0011_0010u8;
+    /// let s1 = 0b1011_0000u8;
+    /// let s2 = 0b1001_0010u8;
+    /// assert_eq!(n.reset_bit(7), s0);
+    /// assert_eq!(n.reset_bit(1), s1);
+    /// assert_eq!(n.reset_bit(5), s2);
+    /// ```
+    fn reset_bit(self, bit: u32) -> Self {
+         self & !(<Self as One>::one() << bit)
+    }
+ 
+    /// Flip the `bit` of `self`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b1011_0010u8;
+    /// let s0 = 0b0011_0010u8;
+    /// let s1 = 0b1111_0010u8;
+    /// let s2 = 0b1001_0010u8;
+    /// assert_eq!(n.flip_bit(7), s0);
+    /// assert_eq!(n.flip_bit(6), s1);
+    /// assert_eq!(n.flip_bit(5), s2);
+    /// ```
+    fn flip_bit(self, bit: u32) -> Self {
+         self ^ (<Self as One>::one() << bit)
+    }
+ 
+    /// Test the `bit` of `self`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b1011_0010u8;
+    /// assert_eq!(n.test_bit(7), true);
+    /// assert_eq!(n.test_bit(6), false);
+    /// assert_eq!(n.test_bit(5), true);
+    /// ```
+    fn test_bit(self, bit: u32) -> bool {
+        self & (<Self as One>::one() << bit) != <Self as Zero>::zero()
+    }
+ 
+    /// Resets all bits of `self` at position >= `bit`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b1111_0010u8;
+    /// let s = 0b0001_0010u8;
+    /// assert_eq!(n.reset_bits_geq(5), s);
+    /// ```
+    fn reset_bits_geq(self, bit: u32) -> Self {
+        self & ((<Self as One>::one() << bit) - <Self as One>::one())
+    }
+ 
+    /// Resets all bits of `self` at position <= `bit`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b1111_0010u8;
+    /// let s = 0b1100_0000u8;
+    /// assert_eq!(n.reset_bits_leq(5), s);
+    /// ```
+    fn reset_bits_leq(self, bit: u32) -> Self {
+        self & !((<Self as One>::one() << (bit + 1)) - <Self as One>::one())
+    }   
+ 
+    /// Sets all bits of `self` at position >= `bit`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b1000_0010u8;
+    /// let s = 0b1110_0010u8;
+    /// assert_eq!(n.set_bits_geq(5), s);
+    /// ```
+    fn set_bits_geq(self, bit: u32) -> Self {
+        self | !((<Self as One>::one() << bit) - <Self as One>::one())
+    }
+ 
+    /// Sets all bits of `self` at position <= `bit`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b1000_0010u8;
+    /// let s = 0b1011_1111u8;
+    /// assert_eq!(n.set_bits_leq(5), s);
+    /// ```
+    fn set_bits_leq(self, bit: u32) -> Self {
+        self | ((<Self as One>::one() << (bit + 1)) - <Self as One>::one())
+    }
+ 
+    /// Flip all bits of `self` at position >= `bit`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b1001_0010u8;
+    /// let s = 0b0111_0010u8;
+    /// assert_eq!(n.flip_bits_geq(5), s);
+    /// ```
+    fn flip_bits_geq(self, bit: u32) -> Self {
+        self ^ !((<Self as One>::one() << bit) - <Self as One>::one())
+    }
+ 
+    /// Flip all bits of `self` at position <= `bit`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b1011_0010u8;
+    /// let s = 0b1000_1101u8;
+    /// assert_eq!(n.flip_bits_leq(5), s);
+    /// ```
+    fn flip_bits_leq(self, bit: u32) -> Self {
+        self ^ ((<Self as One>::one() << (bit + 1)) - <Self as One>::one() )
+    }
+ 
+    /// Is `self` a power of 2
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// assert!(2.is_pow2());
+    /// assert!(!3.is_pow2());
+    /// assert!(4.is_pow2());
+    /// assert!(!5.is_pow2());
+    /// assert!(!6.is_pow2());
+    /// assert!(!7.is_pow2());
+    /// assert!(8.is_pow2());
+    /// ```
+    fn is_pow2(self) -> bool {
+        self > <Self as Zero>::zero()
+        && ((self & (self - <Self as One>::one())) == <Self as Zero>::zero())
+    }
 
-   /// Reset least significant 1 bit of `self`; returns 0 if `self` is 0.
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b0110;
-   /// let s = 0b0100;  
-   ///
-   /// assert_eq!(n.reset_least_significant_one(), s);
-   /// ```
-   fn reset_least_significant_one(self) -> Self {
-       self & (self - <Self as One>::one())
-   }
+    /// Round `self` to the next power of 2
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// assert_eq!(2.ceil_pow2(), 2);
+    /// assert_eq!(3.ceil_pow2(), 4);
+    /// assert_eq!(4.ceil_pow2(), 4);
+    /// assert_eq!(5.ceil_pow2(), 8);
+    /// assert_eq!(6.ceil_pow2(), 8);
+    /// assert_eq!(7.ceil_pow2(), 8);
+    /// assert_eq!(8.ceil_pow2(), 8);
+    /// ```
+    fn ceil_pow2(self)-> Self {
+        let mut x = self - <Self as One>::one();
+        let s = mem::size_of::<Self>();
+        x = x | (x >> 1);
+        x = x | (x >> 2);
+        x = x | (x >> 4);
+        if s > 1 {
+            x = x | (x >> 8);
+            if s > 2 {
+                x = x | (x >> 16);
+                if s > 4 {
+                    x = x | (x >> 32);
+                }
+            }
+        }
+        x + <Self as One>::one()
+    }
 
-   /// Set least significant 0 bit of `self`.
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b0101;
-   /// let s = 0b0111;  
-   ///
-   /// assert_eq!(n.set_least_significant_zero(), s);
-   /// ```
-   fn set_least_significant_zero(self) -> Self {
-       self | (self + <Self as One>::one())
-   }
+    /// Round `self` to the previous power of 2
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// assert_eq!(2.floor_pow2(), 2);
+    /// assert_eq!(3.floor_pow2(), 2);
+    /// assert_eq!(4.floor_pow2(), 4);
+    /// assert_eq!(5.floor_pow2(), 4);
+    /// assert_eq!(6.floor_pow2(), 4);
+    /// assert_eq!(7.floor_pow2(), 4);
+    /// assert_eq!(8.floor_pow2(), 8);
+    /// ```
+    fn floor_pow2(self) -> Self {
+        let mut x = self;
+        let s = mem::size_of::<Self>();
+        x = x | (x >> 1);
+        x = x | (x >> 2);
+        x = x | (x >> 4);
+        if s > 1 {
+            x = x | (x >> 8);
+            if s > 2 {
+                x = x | (x >> 16);
+                if s > 4 {
+                    x = x | (x >> 32);
+                }
+            }
+        }
+        x - (x >> 1)
+    }
 
-   /// Isolate least significant 1 bit of `self` and returns it; returns 0
-   /// if `self` is 0.
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b0110;
-   /// let s = 0b0010;  
-   ///
-   /// assert_eq!(n.isolate_least_significant_one(), s);
-   /// ```
-   fn isolate_least_significant_one(self) -> Self {
-       // note: self & -self is intended, which is rewritten as
-       // self & (0 - self), so:
-       self & (<Self as Zero>::zero() - self)
-   }
+    /// Is `self` aligned to `alignment` bytes
+    ///
+    /// Returns true if `self == 0` or `self` is a multiple of `alignment`.
+    /// 
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// assert!(2.is_aligned(1));
+    /// assert!(2.is_aligned(2));
+    /// assert!(!2.is_aligned(4));
+    /// assert!(!2.is_aligned(8));
+    ///
+    /// assert!(3.is_aligned(1));
+    /// assert!(!3.is_aligned(2));
+    /// assert!(!3.is_aligned(4));
+    /// assert!(!3.is_aligned(8));
+    ///
+    /// assert!(4.is_aligned(1));
+    /// assert!(4.is_aligned(2));
+    /// assert!(4.is_aligned(4));
+    /// assert!(!4.is_aligned(8));
+    /// ```
+    fn is_aligned(self, alignment: u32) -> bool {
+        assert!(alignment > 0);
+        (self & cast::<_, Self>(alignment - 1).unwrap()) == <Self as Zero>::zero()
+    }
 
-   /// Set the least significant zero bit of `self` to 1 and all of the
-   /// rest to 0.
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b0101;
-   /// let s = 0b0010;  
-   ///
-   /// assert_eq!(n.isolate_least_significant_zero(), s);
-   /// ```
-   fn isolate_least_significant_zero(self) -> Self {
-       (!self) & (self + <Self as One>::one())
-   }
+    /// Align `self` up to `alignment`
+    ///
+    /// Returns `n`, where `n` is the least number >= `self`
+    /// and `is_aligned(n, alignment)`.
+    ///
+    /// # Panics
+    ///
+    /// `alignment` must be a power of two which is asserted in debug builds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// assert_eq!(2.align_up(1), 2);
+    /// assert_eq!(2.align_up(2), 2);
+    /// assert_eq!(2.align_up(4), 4);
+    /// assert_eq!(2.align_up(8), 8);
+    ///
+    /// assert_eq!(3.align_up(1), 3);
+    /// assert_eq!(3.align_up(2), 4);
+    /// assert_eq!(3.align_up(4), 4);
+    /// assert_eq!(3.align_up(8), 8);
+    ///
+    /// assert_eq!(4.align_up(1), 4);
+    /// assert_eq!(4.align_up(2), 4);
+    /// assert_eq!(4.align_up(4), 4);
+    /// assert_eq!(4.align_up(8), 8);
+    /// ```
+    fn align_up(self, alignment: u32) -> Self;
 
-   /// Reset the trailing 1's in `self`.
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b0110_1111;
-   /// let s = 0b0110_0000;  
-   ///
-   /// assert_eq!(n.reset_trailing_ones(), s);
-   /// ```
-   fn reset_trailing_ones(self) -> Self {
-       self & (self + <Self as One>::one())
-   }
+    /// Align `self` down to `alignment`
+    ///
+    /// Returns `n`, where `n` is the greatest number <= `self`
+    /// and `is_aligned(n, alignment)`.
+    ///
+    /// # Panics
+    ///
+    /// `alignment` must be a power of two which is asserted in debug builds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// assert_eq!(2.align_down(1), 2);
+    /// assert_eq!(2.align_down(2), 2);
+    /// assert_eq!(2.align_down(4), 0);
+    /// assert_eq!(2.align_down(8), 0);
+    ///
+    /// assert_eq!(3.align_down(1), 3);
+    /// assert_eq!(3.align_down(2), 2);
+    /// assert_eq!(3.align_down(4), 0);
+    /// assert_eq!(3.align_down(8), 0);
+    ///
+    /// assert_eq!(4.align_down(1), 4);
+    /// assert_eq!(4.align_down(2), 4);
+    /// assert_eq!(4.align_down(4), 4);
+    /// assert_eq!(4.align_down(8), 0);
+    /// ```
+    fn align_down(self, alignment: u32) -> Self;
 
-   /// Set all of the trailing 0's in `self`.
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b0110_0000u8;
-   /// let s = 0b0111_1111u8;  
-   ///
-   /// assert_eq!(n.set_trailing_zeros(), s);
-   /// ```
-   fn set_trailing_zeros(self) -> Self {
-       self | (self - <Self as One>::one())
-   }
+    /// Outer Perfect Shuffle
+    ///
+    /// See also [Hacker's Delight: shuffling bits](http://icodeguru.com/Embedded/Hacker's-Delight/047.htm).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b0110_0101_1101_1011_1111_1001_0110_0011u32;
+    /// //        abcd efgh ijkl mnop ABCD EFGH IJKL MNOP, 
+    /// let s = 0b0111_1101_0110_0011_1011_0110_1000_1111u32;
+    /// //        aAbB cCdD eEfF gGhH iIjJ kKlL mMnN oOpP, 
+    ///
+    /// assert_eq!(n.outer_perfect_shuffle(), s);
+    /// ```
+    fn outer_perfect_shuffle(self) -> Self;
 
-   /// Returns a mask with all of the trailing 0's of `self` set.
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b0110_0000u8;
-   /// let s = 0b0001_1111u8;  
-   ///
-   /// assert_eq!(n.mask_trailing_zeros(), s);
-   /// ```
-   fn mask_trailing_zeros(self) -> Self {
-       (!self) & (self - <Self as One>::one())
-   }
+    /// Outer Perfect Unshuffle
+    ///
+    /// See also [Hacker's Delight: shuffling bits](http://icodeguru.com/Embedded/Hacker's-Delight/047.htm).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b0111_1101_0110_0011_1011_0110_1000_1111u32;
+    /// //        aAbB cCdD eEfF gGhH iIjJ kKlL mMnN oOpP, 
+    /// let s = 0b0110_0101_1101_1011_1111_1001_0110_0011u32;
+    /// //        abcd efgh ijkl mnop ABCD EFGH IJKL MNOP, 
+    ///
+    /// assert_eq!(n.outer_perfect_unshuffle(), s);
+    /// ```
+    fn outer_perfect_unshuffle(self) -> Self;
 
-   /// Returns a mask with all of the trailing 1's of `self` set.
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b0101_1111u8;
-   /// let s = 0b0001_1111u8;  
-   ///
-   /// assert_eq!(n.mask_trailing_ones(), s);
-   /// ```
-   fn mask_trailing_ones(self) -> Self {
-       !((!self) | (self + <Self as One>::one()))
-   }
-   
-   /// Returns a mask with all of the trailing 0's of `self` set and the least
-   /// significant 1 bit set.
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b0101_0000u8;
-   /// let s = 0b0001_1111u8;  
-   ///
-   /// assert_eq!(n.mask_trailing_zeros_and_least_significant_one(), s);
-   /// ```
-   fn mask_trailing_zeros_and_least_significant_one(self) -> Self {
-       (self - <Self as One>::one()) ^ self
-   }
+    /// Inner Perfect Shuffle
+    ///
+    /// See also [Hacker's Delight: shuffling bits](http://icodeguru.com/Embedded/Hacker's-Delight/047.htm).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b0110_0101_1101_1011_1111_1001_0110_0011u32;
+    /// //        abcd efgh ijkl mnop ABCD EFGH IJKL MNOP, 
+    /// let s = 0b1011_1110_1001_0011_0111_1001_0100_1111u32;
+    /// //        AaBb CcDd EeFf GgHh IiJj KkLl MmNn OoPp
+    ///
+    /// assert_eq!(n.inner_perfect_shuffle(), s);
+    /// ```
+    fn inner_perfect_shuffle(self) -> Self {
+        self.reverse_bit_groups((mem::size_of::<Self>() * 8 / 2) as u32, 1).outer_perfect_shuffle()
+    }
 
-   /// Returns a mask with all of the trailing 1's of `self` set and the least
-   /// significant 0 bit set.
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b0101_1111u8;
-   /// let s = 0b0011_1111u8;  
-   ///
-   /// assert_eq!(n.mask_trailing_ones_and_least_significant_zero(), s);
-   /// ```
-   fn mask_trailing_ones_and_least_significant_zero(self) -> Self {
-       self ^ (self + <Self as One>::one())
-   }
-
-   /// Reverses the bits of `self` by `subword_bits` and `group_subwords`:
-   ///
-   /// - `subword_bits`: the bits will be reversed in grous:
-   ///   1 (single bits), 2 (pair-wise), 4 (nibbles)
-   /// - `group_subwords`: the subword size is 8 bits: `mem::size_of::<u8>()`,
-   ///   the bits will be reversed within each subword.
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b0101_1101_1010_0101_u16;
-   ///
-   /// // Single bits:
-   /// let s0 = 0b1010_0101_1011_1010u16;
-   /// assert_eq!(n.reverse_bit_groups(1, 1), s0);
-   ///
-   /// // Bit pairs:
-   /// let s1 = 0b0101_1010_0111_0101u16;
-   /// assert_eq!(n.reverse_bit_groups(2, 1), s1);
-   ///
-   /// // Bit nibbles:
-   /// let s2 = 0b0101_1010_1101_0101u16;
-   /// assert_eq!(n.reverse_bit_groups(4, 1), s2);
-   ///
-   /// // Single bits: group_subwords = 2
-   /// let s3 = 0b1011_1010_1010_0101u16;
-   /// assert_eq!(n.reverse_bit_groups(1, 2), s3);
-   ///
-   /// // Bit pairs: group_subwords = 2
-   /// let s4 = 0b0111_0101_0101_1010u16;
-   /// assert_eq!(n.reverse_bit_groups(2, 2), s4);
-   ///
-   /// // Bit nibbles: group_subwords = 2
-   /// let s5 = 0b1101_0101_0101_1010u16;
-   /// assert_eq!(n.reverse_bit_groups(4, 2), s5);
-   /// ```
-   fn reverse_bit_groups(self, subword_bits: u32, group_subwords: u32) -> Self;
-
-   /// Reverses the bits of `self`
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b1011_0010u8;
-   /// let s = 0b0100_1101u8;  
-   /// assert_eq!(n.reverse_bits(), s);
-   ///
-   /// let n1 = 0b1011_0010_1010_1001u16;
-   /// let s1 = 0b1001_0101_0100_1101u16;
-   /// assert_eq!(n1.reverse_bits(), s1);
-   /// ```
-   fn reverse_bits(self) -> Self {
-       self.reverse_bit_groups(1, 1)
-   }
-
-   /// Reverses the pairs of bits of `self`
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b1011_0010u8;
-   /// let s = 0b1000_1110u8;  
-   /// assert_eq!(n.reverse_bit_pairs(), s);
-   ///
-   /// let n1 = 0b1011_0010_1010_1001u16;
-   /// let s1 = 0b0110_1010_1000_1110u16;
-   /// assert_eq!(n1.reverse_bit_pairs(), s1);
-   /// ```
-   fn reverse_bit_pairs(self) -> Self {
-       self.reverse_bit_groups(2, 1)
-   }
-
-   /// Reverses the nibbles of `self`
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b1011_0010u8;
-   /// let s = 0b0010_1011u8;  
-   /// assert_eq!(n.reverse_bit_nibbles(), s);
-   ///
-   /// let n1 = 0b1011_0010_1010_1001u16;
-   /// let s1 = 0b1001_1010_0010_1011u16;
-   /// assert_eq!(n1.reverse_bit_nibbles(), s1);
-   /// ```
-   fn reverse_bit_nibbles(self) -> Self {
-       self.reverse_bit_groups(4, 1)
-   }
-
-   /// Reverses the bytes of `self`
-   ///
-   /// - `bytes_per_block`: number of bytes per block to reverse.
-   /// - `blocks_per_group`: number of blocks per group of blocks.
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b0101_1101_1010_0101_u16;
-   ///
-   /// // Single bytes:
-   /// let s0 = 0b1010_0101_0101_1101u16;
-   /// assert_eq!(n.reverse_byte_groups(1, 1), s0);
-   ///
-   /// // Single bytes: group_subwords = 2
-   /// let s3 = 0b0101_1101_1010_0101u16;
-   /// assert_eq!(n.reverse_byte_groups(1, 2), s3);
-   /// ```
-   fn reverse_byte_groups(self, bytes_per_block: u32, blocks_per_group: u32) -> Self {
-       self.reverse_bit_groups(8 * bytes_per_block, blocks_per_group)
-   }
-
-   /// Reverses the bytes of `self` (equivalent to swap bytes)
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b1011_0010u8;
-   /// let s = 0b1011_0010u8;  
-   /// assert_eq!(n.reverse_bytes(), s);
-   /// assert_eq!(n.swap_bytes(), s);
-   ///
-   /// let n1 = 0b1011_0010_1010_1001u16;
-   /// let s1 = 0b1010_1001_1011_0010u16;
-   /// assert_eq!(n1.reverse_bytes(), s1);
-   /// assert_eq!(n1.swap_bytes(), s1);
-   /// ```
-   fn reverse_bytes(self) -> Self {
-       self.swap_bytes()
-   }
-
-   /// Sets the `bit` of `self`
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n  = 0b1011_0010u8;
-   /// let s0 = 0b1111_0010u8;
-   /// let s1 = 0b1011_0011u8;
-   /// let s2 = 0b1011_1010u8;  
-   /// assert_eq!(n.set_bit(6), s0);
-   /// assert_eq!(n.set_bit(0), s1);
-   /// assert_eq!(n.set_bit(3), s2);
-   /// ```
-   fn set_bit(self, bit: u32) -> Self {
-        self | (<Self as One>::one() << bit)
-   }
-
-   /// Resets the `bit` of `self`
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b1011_0010u8;
-   /// let s0 = 0b0011_0010u8;
-   /// let s1 = 0b1011_0000u8;
-   /// let s2 = 0b1001_0010u8;
-   /// assert_eq!(n.reset_bit(7), s0);
-   /// assert_eq!(n.reset_bit(1), s1);
-   /// assert_eq!(n.reset_bit(5), s2);
-   /// ```
-   fn reset_bit(self, bit: u32) -> Self {
-        self & !(<Self as One>::one() << bit)
-   }
-
-   /// Flip the `bit` of `self`
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b1011_0010u8;
-   /// let s0 = 0b0011_0010u8;
-   /// let s1 = 0b1111_0010u8;
-   /// let s2 = 0b1001_0010u8;
-   /// assert_eq!(n.flip_bit(7), s0);
-   /// assert_eq!(n.flip_bit(6), s1);
-   /// assert_eq!(n.flip_bit(5), s2);
-   /// ```
-   fn flip_bit(self, bit: u32) -> Self {
-        self ^ (<Self as One>::one() << bit)
-   }
-
-   /// Test the `bit` of `self`
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b1011_0010u8;
-   /// assert_eq!(n.test_bit(7), true);
-   /// assert_eq!(n.test_bit(6), false);
-   /// assert_eq!(n.test_bit(5), true);
-   /// ```
-   fn test_bit(self, bit: u32) -> bool {
-       self & (<Self as One>::one() << bit) != <Self as Zero>::zero()
-   }
-
-   /// Resets all bits of `self` at position >= `bit`
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b1111_0010u8;
-   /// let s = 0b0001_0010u8;
-   /// assert_eq!(n.reset_bits_geq(5), s);
-   /// ```
-   fn reset_bits_geq(self, bit: u32) -> Self {
-       self & ((<Self as One>::one() << bit) - <Self as One>::one())
-   }
-
-   /// Resets all bits of `self` at position <= `bit`
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b1111_0010u8;
-   /// let s = 0b1100_0000u8;
-   /// assert_eq!(n.reset_bits_leq(5), s);
-   /// ```
-   fn reset_bits_leq(self, bit: u32) -> Self {
-       self & !((<Self as One>::one() << (bit + 1)) - <Self as One>::one())
-   }   
-
-   /// Sets all bits of `self` at position >= `bit`
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b1000_0010u8;
-   /// let s = 0b1110_0010u8;
-   /// assert_eq!(n.set_bits_geq(5), s);
-   /// ```
-   fn set_bits_geq(self, bit: u32) -> Self {
-       self | !((<Self as One>::one() << bit) - <Self as One>::one())
-   }
-
-   /// Sets all bits of `self` at position <= `bit`
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b1000_0010u8;
-   /// let s = 0b1011_1111u8;
-   /// assert_eq!(n.set_bits_leq(5), s);
-   /// ```
-   fn set_bits_leq(self, bit: u32) -> Self {
-       self | ((<Self as One>::one() << (bit + 1)) - <Self as One>::one())
-   }
-
-   /// Flip all bits of `self` at position >= `bit`
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b1001_0010u8;
-   /// let s = 0b0111_0010u8;
-   /// assert_eq!(n.flip_bits_geq(5), s);
-   /// ```
-   fn flip_bits_geq(self, bit: u32) -> Self {
-       self ^ !((<Self as One>::one() << bit) - <Self as One>::one())
-   }
-
-   /// Flip all bits of `self` at position <= `bit`
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// use num::traits::PrimInt;
-   ///
-   /// let n = 0b1011_0010u8;
-   /// let s = 0b1000_1101u8;
-   /// assert_eq!(n.flip_bits_leq(5), s);
-   /// ```
-   fn flip_bits_leq(self, bit: u32) -> Self {
-       self ^ ((<Self as One>::one() << (bit + 1)) - <Self as One>::one() )
-   }
+    /// Inner Perfect Unshuffle
+    ///
+    /// See also [Hacker's Delight: shuffling bits](http://icodeguru.com/Embedded/Hacker's-Delight/047.htm).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num::traits::PrimInt;
+    ///
+    /// let n = 0b1011_1110_1001_0011_0111_1001_0100_1111u32;
+    /// //        AaBb CcDd EeFf GgHh IiJj KkLl MmNn OoPp
+    /// let s = 0b0110_0101_1101_1011_1111_1001_0110_0011u32;
+    /// //        abcd efgh ijkl mnop ABCD EFGH IJKL MNOP, 
+    ///
+    /// assert_eq!(n.inner_perfect_unshuffle(), s);
+    /// ```
+    fn inner_perfect_unshuffle(self) -> Self {
+        self.outer_perfect_unshuffle().reverse_bit_groups((mem::size_of::<Self>() * 8 / 2) as u32, 1)
+    }
 }
 
 macro_rules! prim_int_impl {
@@ -1507,7 +1760,64 @@ macro_rules! prim_int_impl {
                   up1(4, 32, 0x00000000FFFFFFFFu64, 0xFFFFFFFF00000000u64);
               }
               x as Self
-           }
+            }
+
+            fn align_up(self, alignment: u32) -> Self {
+                assert!(alignment.is_pow2());
+                let x = self.to_unsigned();
+                let a = alignment as Self::Unsigned;
+                ((x + (a - 1)) & !(a - 1)) as Self
+            }
+
+            fn align_down(self, alignment: u32) -> Self {
+                assert!(alignment.is_pow2());
+                self & (!(alignment - 1) as Self)
+            }
+
+            #[allow(exceeding_bitshifts)] fn outer_perfect_shuffle(self) -> Self {
+                let mut x = self;
+                let mut t;
+                let s = mem::size_of::<Self>();
+                if s > 4 {
+                    t = (x ^ (x >> 16)) & 0x00000000FFFF0000u64 as Self;
+                    x = x ^ t ^ (t << 16);
+                }
+                if s > 2 {
+                    t = (x ^ (x >> 8)) & 0x0000FF000000FF00u64 as Self;
+                    x = x ^ t ^ (t << 8);
+                }
+                if s > 1 {
+                    t = (x ^ (x >> 4)) & 0x00F000F000F000F0u64 as Self;
+                    x = x ^ t ^ (t << 4);
+                }
+                t = (x ^ (x >> 2)) & 0x0C0C0C0C0C0C0C0Cu64 as Self;
+                x = x ^ t ^ (t << 2);
+                t = (x ^ (x >> 1)) & 0x2222222222222222u64 as Self;
+                x = x ^ t ^ (t << 1);
+                x
+            }
+
+            #[allow(exceeding_bitshifts)] fn outer_perfect_unshuffle(self) -> Self {
+                let mut x = self;
+                let s = mem::size_of::<Self>();
+                let mut t = (x ^ (x >> 1)) & (0x2222222222222222u64 as Self);
+                x = x ^ t ^ (t << 1);
+                t = (x ^ (x >>  2)) & (0x0C0C0C0C0C0C0C0Cu64 as Self);
+                x = x ^ t ^ (t << 2);
+                if s > 1 {
+                    t = (x ^ (x >> 4)) & (0x00F000F000F000F0u64 as Self);
+                    x = x ^ t ^ (t << 4);
+                }
+                if s > 2 {
+                    t = (x ^ (x >> 8)) & (0x0000FF000000FF00u64 as Self);
+                    x = x ^ t ^ (t << 8);
+                }
+                if s > 4 {
+                    t = (x ^ (x >> 16)) & (0x00000000FFFF0000u64 as Self);
+                    x = x ^ t ^ (t << 16);
+                }
+                return x;
+            }
         }
     )
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1241,7 +1241,7 @@ pub trait PrimInt
    /// assert_eq!(n1.swap_bytes(), s1);
    /// ```
    fn reverse_bytes(self) -> Self {
-       self.reverse_byte_groups(1, 1)
+       self.swap_bytes()
    }
 
    /// Sets the `bit` of `self`

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -676,10 +676,10 @@ pub trait PrimInt
     /// ~~~
     /// use num::traits::PrimInt;
     ///
-    /// assert_eq!((8i32).bits_to_unsigned().bits_to_signed(), 8i32);
-    /// assert_eq!((-1i32).bits_to_unsigned().bits_to_signed(), -1i32);
+    /// assert_eq!((8i32).to_unsigned().to_signed(), 8i32);
+    /// assert_eq!((-1i32).to_unsigned().to_signed(), -1i32);
     /// ~~~
-    fn bits_to_unsigned(self) -> Self::Unsigned;
+    fn to_unsigned(self) -> Self::Unsigned;
 
     /// Transmutes an integer into a signed integer of the
     /// same size (loss less).
@@ -689,10 +689,10 @@ pub trait PrimInt
     /// ~~~
     /// use num::traits::PrimInt;
     ///
-    /// assert_eq!((8i32).bits_to_unsigned().bits_to_signed(), 8i32);
-    /// assert_eq!((-1i32).bits_to_unsigned().bits_to_signed(), -1i32);
+    /// assert_eq!((8i32).to_unsigned().to_signed(), 8i32);
+    /// assert_eq!((-1i32).to_unsigned().to_signed(), -1i32);
     /// ~~~
-    fn bits_to_signed(self) -> Self::Signed;
+    fn to_signed(self) -> Self::Signed;
  
     /// Returns the number of ones in the binary representation of `self`.
     ///
@@ -949,7 +949,7 @@ pub trait PrimInt
    /// assert_eq!(n.reset_least_significant_one(), s);
    /// ```
    fn reset_least_significant_one(self) -> Self {
-       self & (self - cast(1).unwrap())
+       self & (self - <Self as One>::one())
    }
 
    /// Set least significant 0 bit of `self`.
@@ -965,7 +965,7 @@ pub trait PrimInt
    /// assert_eq!(n.set_least_significant_zero(), s);
    /// ```
    fn set_least_significant_zero(self) -> Self {
-       self | (self + cast(1).unwrap())
+       self | (self + <Self as One>::one())
    }
 
    /// Isolate least significant 1 bit of `self` and returns it; returns 0
@@ -982,8 +982,9 @@ pub trait PrimInt
    /// assert_eq!(n.isolate_least_significant_one(), s);
    /// ```
    fn isolate_least_significant_one(self) -> Self {
-       // note: self & -self is intended, which is rewritten as self & (0 - self), so:
-       self & (cast::<_,Self>(0).unwrap() - self)
+       // note: self & -self is intended, which is rewritten as
+       // self & (0 - self), so:
+       self & (<Self as Zero>::zero() - self)
    }
 
    /// Set the least significant zero bit of `self` to 1 and all of the
@@ -1000,7 +1001,7 @@ pub trait PrimInt
    /// assert_eq!(n.isolate_least_significant_zero(), s);
    /// ```
    fn isolate_least_significant_zero(self) -> Self {
-       (!self) & (self + cast(1).unwrap())
+       (!self) & (self + <Self as One>::one())
    }
 
    /// Reset the trailing 1's in `self`.
@@ -1016,7 +1017,7 @@ pub trait PrimInt
    /// assert_eq!(n.reset_trailing_ones(), s);
    /// ```
    fn reset_trailing_ones(self) -> Self {
-       self & (self + cast(1).unwrap())
+       self & (self + <Self as One>::one())
    }
 
    /// Set all of the trailing 0's in `self`.
@@ -1032,7 +1033,7 @@ pub trait PrimInt
    /// assert_eq!(n.set_trailing_zeros(), s);
    /// ```
    fn set_trailing_zeros(self) -> Self {
-       self | (self - cast(1).unwrap())
+       self | (self - <Self as One>::one())
    }
 
    /// Returns a mask with all of the trailing 0's of `self` set.
@@ -1048,7 +1049,7 @@ pub trait PrimInt
    /// assert_eq!(n.mask_trailing_zeros(), s);
    /// ```
    fn mask_trailing_zeros(self) -> Self {
-       (!self) & (self - cast(1).unwrap())
+       (!self) & (self - <Self as One>::one())
    }
 
    /// Returns a mask with all of the trailing 1's of `self` set.
@@ -1064,7 +1065,7 @@ pub trait PrimInt
    /// assert_eq!(n.mask_trailing_ones(), s);
    /// ```
    fn mask_trailing_ones(self) -> Self {
-       !((!self) | (self + cast(1).unwrap()))
+       !((!self) | (self + <Self as One>::one()))
    }
    
    /// Returns a mask with all of the trailing 0's of `self` set and the least
@@ -1081,7 +1082,7 @@ pub trait PrimInt
    /// assert_eq!(n.mask_trailing_zeros_and_least_significant_one(), s);
    /// ```
    fn mask_trailing_zeros_and_least_significant_one(self) -> Self {
-       (self - cast(1).unwrap()) ^ self
+       (self - <Self as One>::one()) ^ self
    }
 
    /// Returns a mask with all of the trailing 1's of `self` set and the least
@@ -1098,7 +1099,7 @@ pub trait PrimInt
    /// assert_eq!(n.mask_trailing_ones_and_least_significant_zero(), s);
    /// ```
    fn mask_trailing_ones_and_least_significant_zero(self) -> Self {
-       self ^ (self + cast(1).unwrap())
+       self ^ (self + <Self as One>::one())
    }
 
    fn general_reverse_bits(self, subword_bits: u32, group_subwords: u32) -> Self;
@@ -1199,7 +1200,7 @@ pub trait PrimInt
    /// assert_eq!(n.set_bit(3), s2);
    /// ```
    fn set_bit(self, bit: u32) -> Self {
-        self | (cast::<_, Self>(1).unwrap() << bit)
+        self | (<Self as One>::one() << bit)
    }
 
    /// Resets the `bit` of `self`
@@ -1218,7 +1219,7 @@ pub trait PrimInt
    /// assert_eq!(n.reset_bit(5), s2);
    /// ```
    fn reset_bit(self, bit: u32) -> Self {
-        self & !(cast::<_, Self>(1).unwrap() << bit)
+        self & !(<Self as One>::one() << bit)
    }
 
    /// Flip the `bit` of `self`
@@ -1237,7 +1238,7 @@ pub trait PrimInt
    /// assert_eq!(n.flip_bit(5), s2);
    /// ```
    fn flip_bit(self, bit: u32) -> Self {
-        self ^ (cast::<_, Self>(1).unwrap() << bit)
+        self ^ (<Self as One>::one() << bit)
    }
 
    /// Test the `bit` of `self`
@@ -1253,7 +1254,7 @@ pub trait PrimInt
    /// assert_eq!(n.test_bit(5), true);
    /// ```
    fn test_bit(self, bit: u32) -> bool {
-        self & (cast::<_, Self>(1).unwrap() << bit) > cast::<_, Self>(0).unwrap()
+       self & (<Self as One>::one() << bit) != <Self as Zero>::zero()
    }
 
    /// Resets all bits of `self` at position >= `bit`
@@ -1268,7 +1269,7 @@ pub trait PrimInt
    /// assert_eq!(n.reset_bits_geq(5), s);
    /// ```
    fn reset_bits_geq(self, bit: u32) -> Self {
-       self & ((cast::<_, Self>(1).unwrap() << bit) - cast::<_, Self>(1).unwrap())
+       self & ((<Self as One>::one() << bit) - <Self as One>::one())
    }
 
    /// Resets all bits of `self` at position <= `bit`
@@ -1283,7 +1284,7 @@ pub trait PrimInt
    /// assert_eq!(n.reset_bits_leq(5), s);
    /// ```
    fn reset_bits_leq(self, bit: u32) -> Self {
-       self & !((cast::<_, Self>(1).unwrap() << (bit + 1)) - cast::<_, Self>(1).unwrap())
+       self & !((<Self as One>::one() << (bit + 1)) - <Self as One>::one())
    }   
 
    /// Sets all bits of `self` at position >= `bit`
@@ -1298,7 +1299,7 @@ pub trait PrimInt
    /// assert_eq!(n.set_bits_geq(5), s);
    /// ```
    fn set_bits_geq(self, bit: u32) -> Self {
-       self | !((cast::<_, Self>(1).unwrap() << bit) - cast::<_, Self>(1).unwrap())
+       self | !((<Self as One>::one() << bit) - <Self as One>::one())
    }
 
    /// Sets all bits of `self` at position <= `bit`
@@ -1313,7 +1314,7 @@ pub trait PrimInt
    /// assert_eq!(n.set_bits_leq(5), s);
    /// ```
    fn set_bits_leq(self, bit: u32) -> Self {
-       self | ((cast::<_, Self>(1).unwrap() << (bit + 1)) - cast::<_, Self>(1).unwrap())
+       self | ((<Self as One>::one() << (bit + 1)) - <Self as One>::one())
    }
 
    /// Flip all bits of `self` at position >= `bit`
@@ -1328,7 +1329,7 @@ pub trait PrimInt
    /// assert_eq!(n.flip_bits_geq(5), s);
    /// ```
    fn flip_bits_geq(self, bit: u32) -> Self {
-       self ^ !((cast::<_, Self>(1).unwrap() << bit) - cast::<_, Self>(1).unwrap())
+       self ^ !((<Self as One>::one() << bit) - <Self as One>::one())
    }
 
    /// Flip all bits of `self` at position <= `bit`
@@ -1343,7 +1344,7 @@ pub trait PrimInt
    /// assert_eq!(n.flip_bits_leq(5), s);
    /// ```
    fn flip_bits_leq(self, bit: u32) -> Self {
-       self ^ ((cast::<_, Self>(1).unwrap() << (bit + 1)) - cast::<_, Self>(1).unwrap())
+       self ^ ((<Self as One>::one() << (bit + 1)) - <Self as One>::one() )
    }
 }
 
@@ -1353,12 +1354,12 @@ macro_rules! prim_int_impl {
             type Signed = $AS;
             type Unsigned = $AU;
 
-            fn bits_to_unsigned(self) -> $AU
+            fn to_unsigned(self) -> $AU
             {
                 self as $AU
             }
 
-            fn bits_to_signed(self) -> $AS
+            fn to_signed(self) -> $AS
             {
                 self as $AS
             }
@@ -1411,45 +1412,40 @@ macro_rules! prim_int_impl {
                 <$T>::pow(self, exp)
             }
 
-           fn general_reverse_bits(self, subword_bits: u32, group_subwords: u32) -> Self {
+            fn general_reverse_bits(self, subword_bits: u32, group_subwords: u32) -> Self {
               // Adapted from Matthew Fioravante's stdcxx-bitops, which
               // is released under the MIT's License here:
               // https://github.com/fmatthew5876/stdcxx-bitops
            
-              let mut x: Self::Unsigned = self.bits_to_unsigned();
-              println!("input {:b}, as unsigned: {:b}, subword_bits: {}, group_subwords: {}", self, x, subword_bits, group_subwords);
+              let mut x: Self::Unsigned = self.to_unsigned();
               let width: u32  = mem::size_of::<Self>() as u32;
               let group_sz: u32 = width * 8 / group_subwords;
               let k: u32 = group_sz - subword_bits;
-              println!("k {}", k);
               {
-                  let mut up0 = |i: u32, l: usize, r: usize| {
+                  let mut up0 = |i: u32, l: u64, r: u64| {
                       if k & i > 0 {
                           x = ((x & (l as Self::Unsigned)) << (i as Self::Unsigned))
                               | ((x & (r as Self::Unsigned)) >> (i as Self::Unsigned));
                       }
-                      println!("up0({}): x = {:b}", i, x);
                   };
 
-                  up0(1, 0x5555555555555555usize, 0xAAAAAAAAAAAAAAAAusize);
-                  up0(2, 0x3333333333333333usize, 0xCCCCCCCCCCCCCCCCusize);
-                  up0(4, 0x0F0F0F0F0F0F0F0Fusize, 0xF0F0F0F0F0F0F0F0usize);
+                  up0(1, 0x5555555555555555u64, 0xAAAAAAAAAAAAAAAAu64);
+                  up0(2, 0x3333333333333333u64, 0xCCCCCCCCCCCCCCCCu64);
+                  up0(4, 0x0F0F0F0F0F0F0F0Fu64, 0xF0F0F0F0F0F0F0F0u64);
               }
 
               {
-                  let mut up1 = |i: u32, s: u32, l: usize, r: usize| {
+                  let mut up1 = |i: u32, s: u32, l: u64, r: u64| {
                       if width > i && (k & s > 0) {
                           x = ((x & (l as Self::Unsigned)) << (s as Self::Unsigned))
                               | ((x & (r as Self::Unsigned)) >> (s as Self::Unsigned));
                       }
-                      println!("up1({}): x = {:b}", i, x);
                   };
 
-                  up1(1, 8, 0x00FF00FF00FF00FFusize, 0xFF00FF00FF00FF00usize);
-                  up1(2, 16, 0x0000FFFF0000FFFFusize, 0xFFFF0000FFFF0000usize);
-                  up1(4, 32, 0x00000000FFFFFFFFusize, 0xFFFFFFFF00000000usize);
+                  up1(1, 8, 0x00FF00FF00FF00FFu64, 0xFF00FF00FF00FF00u64);
+                  up1(2, 16, 0x0000FFFF0000FFFFu64, 0xFFFF0000FFFF0000u64);
+                  up1(4, 32, 0x00000000FFFFFFFFu64, 0xFFFFFFFF00000000u64);
               }
-              println!("output {:b}, as Self {:b}", x, x as Self);
               x as Self
            }
         }


### PR DESCRIPTION
This adds to the `PrimInt` trait:
- two associated types: `Signed`/`Unsigned`, which contains a type of the same `mem::size_of` as `Self`, but with the corresponding signedness, and two functions `bits_to_signed/unsigned -> Signed/Unsigned`; fixes #141 .
- modifies the requirements of `Shl``Shr`to require`u32`instead of`usize`, fixes #80 .
- some bit manipulation algorithms, mainly adapted from the [C++ bitops proposal](https://github.com/fmatthew5876/stdcxx-bitopsstd). 

Most of the algorithms have sub-optimal implementations since:
- the fastest implementation is to use either a compiler intrinsic or a platform-dependent intrinsic (e.g. extracting/depositing bits with Intel's BMI2.0 is much faster than any hand-rolled implementation).
- I wanted to get correct implementations working first, add lots of tests, and optimize later,
- some optimizations are size dependent, and while some times mem::size_of is used to help the compiler, they are better provided in different implementations for each type.

TODOs:
- revert `Shl<u32>` to `Shl<usize>`
- gather consensus around whether we need the associated types Signed/Unsigned or not and about how these should be implemented (maybe in a different trait that requires `PrimInt` to avoid breaking its API). 
- TODO: find real world examples of the associated types or remove them
- TODO: document the intrinsics that should be used for each algorithm
- TODO: add assertions
- TODO: where to put the bit manipulation algorithms
- TODO: many more tests
