### PR TITLE
Add linspace(), a sequence of evenly spaced floats

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -263,6 +263,7 @@ impl<A> Iterator for RangeStepInclusive<A>
 /// Created from `linspace()`.
 ///
 /// Iterator element type is `F`.
+#[derive(Clone, Debug)]
 pub struct Linspace<F> {
     start: F,
     step: F,


### PR DESCRIPTION
Linspace produces `n` elements between a and b, both ends inclusive.

We compute `step = (b - a)/(n - 1)` and each element as `a + i * step`
where `i` is the iteration counter.

This method is equivalent to what Python's numpy.linspace does, and it
also makes sure the iterator can be double ended (an accumulation would
not be reversible due to rounding errors).

This iterator has previously appeared in itertools, but it has a better
home in num.