### PR TITLE
bigint: small to_str_radix optimization

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -1471,8 +1471,12 @@ fn to_str_radix_reversed(u: &BigUint, radix: u32) -> Vec<u8> {
 
     // Now convert everything to ASCII digits.
     for r in &mut res {
-        const DIGITS: &'static [u8; 36] = b"0123456789abcdefghijklmnopqrstuvwxyz";
-        *r = DIGITS[*r as usize];
+        debug_assert!((*r as u32) < radix);
+        if *r < 10 {
+            *r += b'0';
+        } else {
+            *r += b'a' - 10;
+        }
     }
     res
 }


### PR DESCRIPTION
Before:
```
test fac_to_string     ... bench:       1,630 ns/iter (+/- 34)
test fib_to_string     ... bench:         359 ns/iter (+/- 11)
test to_str_radix_02   ... bench:       3,097 ns/iter (+/- 19)
test to_str_radix_08   ... bench:       1,146 ns/iter (+/- 38)
test to_str_radix_10   ... bench:       4,248 ns/iter (+/- 36)
test to_str_radix_16   ... bench:         881 ns/iter (+/- 44)
test to_str_radix_36   ... bench:       8,073 ns/iter (+/- 75)
```
After:
```
test fac_to_string     ... bench:       1,492 ns/iter (+/- 20)
test fib_to_string     ... bench:         368 ns/iter (+/- 7)
test to_str_radix_02   ... bench:       2,038 ns/iter (+/- 47)
test to_str_radix_08   ... bench:         812 ns/iter (+/- 9)
test to_str_radix_10   ... bench:       3,919 ns/iter (+/- 40)
test to_str_radix_16   ... bench:         703 ns/iter (+/- 58)
test to_str_radix_36   ... bench:       7,852 ns/iter (+/- 81)
```