### PR TITLE
Improve pow speed for expensive types by multiplying references not cloned values

### DIFF
--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -192,7 +192,7 @@ fn hash(b: &mut Bencher) {
 #[bench]
 fn pow_bench(b: &mut Bencher) {
     b.iter(|| {
-        let upper = 250_usize;
+        let upper = 100_usize;
         for i in 2..upper + 1 {
             for j in 2..upper + 1 {
                 let i_big = BigUint::from_usize(i).unwrap();

--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -188,3 +188,16 @@ fn hash(b: &mut Bencher) {
         assert_eq!(h.len(), v.len());
     });
 }
+
+#[bench]
+fn pow_bench(b: &mut Bencher) {
+    b.iter(|| {
+        let upper = 250_usize;
+        for i in 2..upper + 1 {
+            for j in 2..upper + 1 {
+                let i_big = BigUint::from_usize(i).unwrap();
+                num::pow(i_big, j);
+            }
+        }
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,22 +141,23 @@ pub fn abs_sub<T: Signed>(x: T, y: T) -> T {
 /// ```
 #[inline]
 pub fn pow<T: Clone + One + Mul<T, Output = T>>(mut base: T, mut exp: usize) -> T {
-    if exp == 1 { base }
-    else {
-        let mut acc = one::<T>();
-        while exp > 0 {
-            if (exp & 1) == 1 {
-                acc = acc * base.clone();
-            }
+    if exp == 0 { return T::one() }
 
-            // avoid overflow if we won't need it
-            if exp > 1 {
-                base = base.clone() * base;
-            }
-            exp = exp >> 1;
-        }
-        acc
+    while exp & 1 == 0 {
+        base = base.clone() * base;
+        exp >>= 1;
     }
+    if exp == 1 { return base }
+
+    let mut acc = base.clone();
+    while exp > 1 {
+        exp >>= 1;
+        base = base.clone() * base;
+        if exp & 1 == 1 {
+            acc = acc * base.clone();
+        }
+    }
+    acc
 }
 
 #[cfg(test)]


### PR DESCRIPTION
pow can be made cheaper for types that are expensive to clone such as BigUInt.

includes a benchmark that goes from
`test pow_bench         ... bench: 159,222,506 ns/iter (+/- 8,973,716)`
to
`test pow_bench         ... bench: 140,754,320 ns/iter (+/- 7,129,689)`


not sure if this is a breaking change though if Mul for references isn't implemented?