### PR TITLE
Improve pow speed for expensive types by multiplying references not cloned values (reopen)

### DIFF
--- a/traits/src/pow.rs
+++ b/traits/src/pow.rs
@@ -12,11 +12,14 @@ use {One, CheckedMul};
 /// assert_eq!(pow(6u8, 3), 216);
 /// ```
 #[inline]
-pub fn pow<T: Clone + One + Mul<T, Output = T>>(mut base: T, mut exp: usize) -> T {
+pub fn pow<T: Clone + One + Mul<T, Output = T>>(mut base: T, mut exp: usize) -> T
+where
+    for<'a> &'a T: Mul<&'a T, Output = T>,
+{
     if exp == 0 { return T::one() }
 
     while exp & 1 == 0 {
-        base = base.clone() * base;
+        base = &base * &base;
         exp >>= 1;
     }
     if exp == 1 { return base }
@@ -24,9 +27,9 @@ pub fn pow<T: Clone + One + Mul<T, Output = T>>(mut base: T, mut exp: usize) -> 
     let mut acc = base.clone();
     while exp > 1 {
         exp >>= 1;
-        base = base.clone() * base;
+        base = &base * &base;
         if exp & 1 == 1 {
-            acc = acc * base.clone();
+            acc = &acc * &base;
         }
     }
     acc


### PR DESCRIPTION
Resubmission of https://github.com/rust-num/num/pull/152
Couldn't reopen because I broke the branch

Speed up on pow_bench

```
   test pow_bench         ... bench:   9,579,445 ns/iter (+/- 560,439)
-> test pow_bench         ... bench:   6,820,137 ns/iter (+/- 760,415)
```
