### PR TITLE
Make `rand` and `rustc-serialize` dependencies optional.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,17 @@ complex, rational, range iterators, generic integers, and more!
 rustc-serialize = { version = "0.3.13", optional = true }
 rand = { version = "0.3.8", optional = true }
 
+[dev-dependencies]
+# Some tests of non-rand functionality still use rand because the tests
+# themselves are randomized.
+rand = { version = "0.3.8" }
+
 [features]
 
 complex = []
 rational = []
-bigint = ["rustc-serialize", "rand"]
-default = ["complex", "rational", "bigint"]
+bigint = []
+default = ["bigint", "complex", "rand", "rational", "rustc-serialize"]
 
 [[bench]]
 name = "bigint"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,11 @@
 
 #[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;
-#[cfg(feature = "rand")]
+
+// Some of the tests of non-RNG-based functionality are randomized using the
+// RNG-based functionality, so the RNG-based functionality needs to be enabled
+// for tests.
+#[cfg(any(feature = "rand", all(feature = "bigint", test)))]
 extern crate rand;
 
 #[cfg(feature = "bigint")]


### PR DESCRIPTION
Previously, the `rand` and `rustc-serialize` dependencies were optional
except they were required for the `bigint` feature.

Make the dependency on the `rand` crate optional in all cases.
including when the `bigint` feature is selected. Some of the tests for
the bigint feature are randomized so, while `rand` is now an optional
dependency, it is a non-optional dev-dependency.

Similarly, make the dependency on the `rustc-serialize` crate optional
in all cases, including when the `bigint` feature is selected.