### PR TITLE
Update num_macros to current nightly

### DIFF
--- a/num-macros/src/lib.rs
+++ b/num-macros/src/lib.rs
@@ -14,7 +14,7 @@ extern crate syntax;
 extern crate syntax_ext;
 extern crate rustc_plugin;
 
-use syntax::ast::{MetaItem, Expr};
+use syntax::ast::{MetaItem, Expr, BinOpKind};
 use syntax::ast;
 use syntax::codemap::Span;
 use syntax::ext::base::{ExtCtxt, Annotatable};
@@ -142,7 +142,7 @@ fn cs_from(name: &str, cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure
                         let variant = cx.expr_path(path);
                         let ty = cx.ty_ident(span, cx.ident_of(name));
                         let cast = cx.expr_cast(span, variant.clone(), ty);
-                        let guard = cx.expr_binary(span, ast::BiEq, n.clone(), cast);
+                        let guard = cx.expr_binary(span, BinOpKind::Eq, n.clone(), cast);
 
                         // expr for `Some($variant)`
                         let body = cx.expr_some(span, variant);


### PR DESCRIPTION
Fixes num_macros build for current nightly, broken by [this](https://github.com/rust-lang/rust/pull/31487/files) PR on rust.