### PR TITLE
Add support for Serde 0.7.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,9 @@ complex, rational, range iterators, generic integers, and more!
 """
 
 [dependencies]
-rustc-serialize = { version = "0.3.13", optional = true }
 rand = { version = "0.3.8", optional = true }
+rustc-serialize = { version = "0.3.13", optional = true }
+serde = { version = "^0.7.0", optional = true }
 
 [dev-dependencies]
 # Some tests of non-rand functionality still use rand because the tests

--- a/src/complex.rs
+++ b/src/complex.rs
@@ -14,6 +14,9 @@
 use std::fmt;
 use std::ops::{Add, Div, Mul, Neg, Sub};
 
+#[cfg(feature = "serde")]
+use serde;
+
 use {Zero, One, Num, Float};
 
 // FIXME #1284: handle complex NaN & infinity etc. This
@@ -564,6 +567,29 @@ impl<T> fmt::Display for Complex<T> where
         } else {
             write!(f, "{}+{}i", self.re, self.im)
         }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T> serde::Serialize for Complex<T>
+    where T: serde::Serialize
+{
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where
+        S: serde::Serializer
+    {
+        (&self.re, &self.im).serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T> serde::Deserialize for Complex<T> where
+    T: serde::Deserialize + Num + Clone
+{
+    fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error> where
+        D: serde::Deserializer,
+    {
+        let (re, im) = try!(serde::Deserialize::deserialize(deserializer));
+        Ok(Complex::new(re, im))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,9 @@ extern crate rustc_serialize;
 #[cfg(any(feature = "rand", all(feature = "bigint", test)))]
 extern crate rand;
 
+#[cfg(feature = "serde")]
+extern crate serde;
+
 #[cfg(feature = "bigint")]
 pub use bigint::{BigInt, BigUint};
 #[cfg(feature = "rational")]


### PR DESCRIPTION
Serde 0.7 dropped it's dependency on num, so this patch moves the implementations here. For the sake of a better implementation, this just serializes BigUint as a `Vec<u32>`, `BigInt` as a `(u8, Vec<u32>)`, `Complex<T>` as a `(T, T)`, and `Ratio<T>` as a `(T, T)`.