### PR TITLE
Saturating<T> wrapper type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,7 @@ pub mod complex;
 pub mod integer;
 pub mod iter;
 pub mod traits;
+pub mod saturating;
 #[cfg(feature = "rational")]
 pub mod rational;
 

--- a/src/saturating.rs
+++ b/src/saturating.rs
@@ -253,10 +253,8 @@ macro_rules! impl_saturating_sh_unsigned {
 
             #[inline(always)]
             fn shr(self, rhs: $f) -> Self::Output {
-                if self.0 == 0 {
-                    Saturating(0)
-                }
-                else if rhs > $bits - 1 {
+                // Fine for unsigned, 0 is smallest value
+                if rhs > $bits - 1 {
                     Saturating(<$t>::min_value())
                 }
                 else {

--- a/src/saturating.rs
+++ b/src/saturating.rs
@@ -1,0 +1,341 @@
+use std::mem::size_of;
+use std::ops::{Add, Sub, Mul, Div, Rem, Not, Neg, BitXor, BitOr, BitAnd, Shl, Shr};
+
+use traits::{Bounded, Num, One, Signed, Unsigned, Zero};
+use traits::Saturating as SaturatingOps;
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Default)]
+pub struct Saturating<T>(pub T);
+
+macro_rules! impl_saturating {
+    ( $t:ident ) => {
+        impl Add for Saturating<$t> {
+            type Output = Saturating<$t>;
+
+            #[inline(always)]
+            fn add(self, rhs: Saturating<$t>) -> Self::Output {
+                Saturating(self.0.saturating_add(rhs.0))
+            }
+        }
+
+        impl Sub for Saturating<$t> {
+            type Output = Saturating<$t>;
+
+            #[inline(always)]
+            fn sub(self, rhs: Saturating<$t>) -> Self::Output {
+                Saturating(self.0.saturating_sub(rhs.0))
+            }
+        }
+
+        impl Div for Saturating<$t> {
+            type Output = Saturating<$t>;
+
+            #[inline(always)]
+            fn div(self, rhs: Saturating<$t>) -> Self::Output {
+                Saturating(self.0 / rhs.0)
+            }
+        }
+
+        impl Not for Saturating<$t> {
+            type Output = Saturating<$t>;
+
+            #[inline(always)]
+            fn not(self) -> Self::Output {
+                Saturating(!self.0)
+            }
+        }
+
+        impl BitXor for Saturating<$t> {
+            type Output = Saturating<$t>;
+
+            #[inline(always)]
+            fn bitxor(self, rhs: Saturating<$t>) -> Self::Output {
+                Saturating(self.0 ^ rhs.0)
+            }
+        }
+
+        impl BitOr for Saturating<$t> {
+            type Output = Saturating<$t>;
+
+            #[inline(always)]
+            fn bitor(self, rhs: Saturating<$t>) -> Self::Output {
+                Saturating(self.0 | rhs.0)
+            }
+        }
+
+        impl BitAnd for Saturating<$t> {
+            type Output = Saturating<$t>;
+
+            #[inline(always)]
+            fn bitand(self, rhs: Saturating<$t>) -> Self::Output {
+                Saturating(self.0 & rhs.0)
+            }
+        }
+
+        impl Zero for Saturating<$t> {
+            #[inline(always)]
+            fn zero() -> Self {
+                Saturating(0)
+            }
+
+            #[inline(always)]
+            fn is_zero(&self) -> bool {
+                self.0 == 0
+            }
+        }
+
+        impl One for Saturating<$t> {
+            #[inline(always)]
+            fn one() -> Self {
+                Saturating(1)
+            }
+        }
+
+        impl Num for Saturating<$t> {
+            type FromStrRadixErr = ::std::num::ParseIntError;
+
+            #[inline(always)]
+            fn from_str_radix(s: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
+                <$t>::from_str_radix(s, radix).map(Saturating)
+            }
+        }
+
+        impl Bounded for Saturating<$t> {
+            #[inline(always)]
+            fn min_value() -> Self {
+                Saturating($t::min_value())
+            }
+
+            #[inline(always)]
+            fn max_value() -> Self {
+                Saturating($t::min_value())
+            }
+        }
+    };
+}
+
+macro_rules! impl_saturating_unsigned {
+    ( $t:ident ) => {
+        impl_saturating!{$t}
+
+        impl Unsigned for Saturating<$t> {}
+
+        impl Mul for Saturating<$t> {
+            type Output = Saturating<$t>;
+
+            #[inline(always)]
+            fn mul(self, rhs: Saturating<$t>) -> Self::Output {
+                Saturating(self.0.checked_mul(rhs.0).unwrap_or($t::max_value()))
+            }
+        }
+
+        impl Rem for Saturating<$t> {
+            type Output = Saturating<$t>;
+
+            #[inline(always)]
+            fn rem(self, rhs: Saturating<$t>) -> Self::Output {
+                if rhs.0 == 0 {
+                    Saturating($t::max_value())
+                } else {
+                    Saturating(self.0 % rhs.0)
+                }
+            }
+        }
+    };
+    ( $($t:ident)* ) => { $(impl_saturating_unsigned!{$t})* };
+}
+
+macro_rules! impl_saturating_signed {
+    ( $t:ident ) => {
+        impl_saturating!{$t}
+
+        impl Mul for Saturating<$t> {
+            type Output = Saturating<$t>;
+
+            #[inline(always)]
+            fn mul(self, rhs: Saturating<$t>) -> Self::Output {
+                Saturating(self.0.checked_mul(rhs.0).unwrap_or_else(||
+                    if self.0 < 0 && rhs.0 < 0 || self.0 > 0 && rhs.0 > 0 {
+                        $t::max_value()
+                    } else {
+                        $t::min_value()
+                    }))
+            }
+        }
+
+        impl Rem for Saturating<$t> {
+            type Output = Saturating<$t>;
+
+            #[inline(always)]
+            fn rem(self, rhs: Saturating<$t>) -> Self::Output {
+                if rhs.0 == 0 {
+                    Saturating($t::max_value())
+                } else if self.0 == $t::min_value() && rhs.0 == -1 {
+                    Saturating(self.0)
+                } else {
+                    Saturating(self.0 % rhs.0)
+                }
+            }
+        }
+
+        impl Neg for Saturating<$t> {
+            type Output = Saturating<$t>;
+
+            #[inline(always)]
+            fn neg(self) -> Self::Output {
+                // Negating minimum causes overflow
+                if self.0 == $t::min_value() {
+                    Saturating($t::max_value())
+                } else {
+                    Saturating(-self.0)
+                }
+            }
+        }
+
+        impl Signed for Saturating<$t> {
+            #[inline(always)]
+            fn abs(&self) -> Self {
+                // According to documentation abs(::MIN) -> ::MIN
+                if self.0 == $t::min_value() {
+                    Saturating(self.0)
+                }
+                else if self.is_negative() {
+                    -*self
+                }
+                else {
+                    *self
+                }
+            }
+
+            #[inline(always)]
+            fn abs_sub(&self, other: &Self) -> Self {
+                if *self <= *other { Saturating(0) } else { *self - *other }
+            }
+
+            #[inline(always)]
+            fn signum(&self) -> Self {
+                match self.0 {
+                    n if n > 0 => Saturating(1),
+                    0          => Saturating(0),
+                    _          => Saturating(-1),
+                }
+            }
+
+            #[inline(always)]
+            fn is_positive(&self) -> bool {
+                self.0 > 0
+            }
+
+            #[inline(always)]
+            fn is_negative(&self) -> bool {
+                self.0 < 0
+            }
+        }
+    };
+    ( $($t:ident)* ) => { $(impl_saturating_signed!{$t})* };
+}
+
+macro_rules! impl_saturating_sh_unsigned {
+    ( $t:ident, $bits:expr, $f:ident ) => {
+        impl Shl<$f> for Saturating<$t> {
+            type Output = Saturating<$t>;
+
+            #[inline(always)]
+            fn shl(self, rhs: $f) -> Self::Output {
+                if self.0 == 0 {
+                    Saturating(0)
+                }
+                else if rhs > $bits - 1 {
+                    Saturating($t::max_value())
+                }
+                else {
+                    Saturating(self.0 << rhs)
+                }
+            }
+        }
+
+        impl Shr<$f> for Saturating<$t> {
+            type Output = Saturating<$t>;
+
+            #[inline(always)]
+            fn shr(self, rhs: $f) -> Self::Output {
+                if self.0 == 0 {
+                    Saturating(0)
+                }
+                else if rhs > $bits - 1 {
+                    Saturating($t::min_value())
+                }
+                else {
+                    Saturating(self.0 >> rhs)
+                }
+            }
+        }
+    };
+    ( $t:ident, $bits:expr, ( $($f:ident)* ) ) => {
+        $(impl_saturating_shl_unsigned!{$t, $bits, $f})*
+    };
+}
+
+macro_rules! impl_saturating_sh_signed {
+    ( $t:ident, $bits:expr, $f:ident ) => {
+        impl Shl<$f> for Saturating<$t> {
+            type Output = Saturating<$t>;
+
+            #[inline(always)]
+            fn shl(self, rhs: $f) -> Self::Output {
+                if self.0 == 0 {
+                    Saturating(0)
+                }
+                // sign bit is kept when shifting left at most $bits - 1 on negative number
+                else if self.0 < 0 && rhs > $bits - 1 {
+                    Saturating($t::min_value())
+                }
+                // shifting $bits - 1 results in negative number, only allow $bits - 2 shifts on
+                // nonnegative numbers
+                else if rhs > $bits - 2 {
+                    Saturating($t::max_value())
+                } else {
+                    Saturating(self.0 << rhs)
+                }
+            }
+        }
+
+        impl Shr<$f> for Saturating<$t> {
+            type Output = Saturating<$t>;
+
+            #[inline(always)]
+            fn shr(self, rhs: $f) -> Self::Output {
+                if self.0 == 0 {
+                    Saturating(0)
+                }
+                // Negative values always keep sign bit on right shift
+                else if self.0 < 0 && rhs > $bits - 1 {
+                    Saturating(-1)
+                }
+                // Positive values saturate to zero
+                else if rhs > $bits - 1 {
+                    Saturating(0)
+                }
+                else {
+                    Saturating(self.0 >> rhs)
+                }
+            }
+        }
+    };
+    ( $t:ident, $bits:expr, ( $($f:ident)* ) ) => {
+        $(impl_saturating_shl_unsigned!{$t, $bits, $f})*
+    };
+}
+
+impl_saturating_unsigned!{u8 u16 u32 u64 usize}
+impl_saturating_signed!{i8 i16 i32 i64 isize}
+impl_saturating_sh_unsigned!{u8, 8, usize}
+impl_saturating_sh_unsigned!{u16, 16, usize}
+impl_saturating_sh_unsigned!{u32, 16, usize}
+impl_saturating_sh_unsigned!{u64, 16, usize}
+impl_saturating_sh_unsigned!{usize, size_of::<usize>() * 8, usize}
+impl_saturating_sh_signed!{i8, 8, usize}
+impl_saturating_sh_signed!{i16, 16, usize}
+impl_saturating_sh_signed!{i32, 16, usize}
+impl_saturating_sh_signed!{i64, 16, usize}
+impl_saturating_sh_signed!{isize, size_of::<isize>() * 8, usize}

--- a/src/saturating.rs
+++ b/src/saturating.rs
@@ -135,6 +135,7 @@ macro_rules! impl_saturating_unsigned {
 
             #[inline(always)]
             fn rem(self, rhs: Saturating<$t>) -> Self::Output {
+                // Cannot overflow in unsigned
                 Saturating(self.0 % rhs.0)
             }
         }
@@ -179,8 +180,9 @@ macro_rules! impl_saturating_signed {
 
             #[inline(always)]
             fn rem(self, rhs: Saturating<$t>) -> Self::Output {
+                // Overflow when MIN % -1 = MAX + 1 (since MIN is even in two's complement)
                 if self.0 == <$t>::min_value() && rhs.0 == -1 {
-                    Saturating(self.0)
+                    Saturating(<$t>::max_value())
                 } else {
                     Saturating(self.0 % rhs.0)
                 }

--- a/src/saturating.rs
+++ b/src/saturating.rs
@@ -125,7 +125,7 @@ macro_rules! impl_saturating_base {
 
             #[inline(always)]
             fn max_value() -> Self {
-                Saturating(<$t>::min_value())
+                Saturating(<$t>::max_value())
             }
         }
     };

--- a/src/saturating.rs
+++ b/src/saturating.rs
@@ -134,11 +134,7 @@ macro_rules! impl_saturating_unsigned {
 
             #[inline(always)]
             fn rem(self, rhs: Saturating<$t>) -> Self::Output {
-                if rhs.0 == 0 {
-                    Saturating(<$t>::max_value())
-                } else {
-                    Saturating(self.0 % rhs.0)
-                }
+                Saturating(self.0 % rhs.0)
             }
         }
     };
@@ -168,9 +164,7 @@ macro_rules! impl_saturating_signed {
 
             #[inline(always)]
             fn rem(self, rhs: Saturating<$t>) -> Self::Output {
-                if rhs.0 == 0 {
-                    Saturating(<$t>::max_value())
-                } else if self.0 == <$t>::min_value() && rhs.0 == -1 {
+                if self.0 == <$t>::min_value() && rhs.0 == -1 {
                     Saturating(self.0)
                 } else {
                     Saturating(self.0 % rhs.0)

--- a/src/saturating.rs
+++ b/src/saturating.rs
@@ -1,3 +1,5 @@
+//! Module containing a saturating wrapper type.
+//!
 //! Rust's integer types are defined to overflow with two's complement by default if checking is not
 //! enabled (see https://github.com/rust-lang/rfcs/blob/master/text/0560-integer-overflow.md). To
 //! intentionally cause wrappng the type `Wrapping<T>` is used.
@@ -164,6 +166,10 @@ macro_rules! impl_saturating_unsigned {
     };
 }
 
+// Implementation of traits for signed types.
+//
+// We can rely on two's complement for these signed machine types:
+// https://doc.rust-lang.org/reference.html#machine-types
 macro_rules! impl_saturating_signed {
     ( $t:ty ) => {
         impl Mul for Saturating<$t> {
@@ -262,7 +268,6 @@ macro_rules! impl_saturating_signed {
             }
         }
     };
-    ( $($t:ty)* ) => { $(impl_saturating_signed!{$t})* };
 }
 
 macro_rules! impl_saturating_sh_unsigned {
@@ -313,10 +318,14 @@ macro_rules! impl_saturating_sh_signed {
                 fn signed_leading_zeros(n: $t) -> $f {
                     debug_assert!(n != 0);
 
+                    // According to https://doc.rust-lang.org/reference.html#unary-operator-expressions
+                    // rust negates the two's complement representation in negation of signed integer
+                    // types.
+
                     // According to two's complement representation, we can get the positive
-                    // representation by negating and adding 1 in the case of the sign bit being
-                    // set. In this case we can just remove 1 from the number of leading zeros
-                    // instead:
+                    // representation by bitwise negating and adding 1 in the case of the sign bit
+                    // being set. In this case we can just remove 1 from the number of leading
+                    // zeros instead:
                     if n > 0 {
                         // sign bit never set, at least one leading zero
                         (n.leading_zeros() - 1) as $f


### PR DESCRIPTION
Rust's stdlib has a [`Wrapping<T>`](http://doc.rust-lang.org/nightly/std/num/struct.Wrapping.html) wrapper type for primitive integer types. The type provides intentionally wrapping semantics to all operations performed on it.

This pull-request introduces a `Saturating<T>` wrapper type which is the corresponding saturating wrapper type for primitive integer types. This type provides saturating semantics on arithmetic and bit-shifting operations for both signed and unsigned integers.

The goal is to provide a type which is easy to slot in instead of either `Wrapping<T>` or any basic integer type. Combined with the traits in `num` it would be possible to make functions/methods generic over the type of integer and if it should have wrapping or saturating semantics.

The name `Saturating<T>` collides with the trait `Saturating` which is unfortunate. I suspect that this type will need a name change but at the moment I do not have any suggestions.
