### PR TITLE
num: remove `pub` from sub-crates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,15 +57,15 @@
        html_root_url = "http://rust-num.github.io/num/",
        html_playground_url = "http://play.rust-lang.org/")]
 
-pub extern crate num_traits;
-pub extern crate num_integer;
-pub extern crate num_iter;
+extern crate num_traits;
+extern crate num_integer;
+extern crate num_iter;
 #[cfg(feature = "num-complex")]
-pub extern crate num_complex;
+extern crate num_complex;
 #[cfg(feature = "num-bigint")]
-pub extern crate num_bigint;
+extern crate num_bigint;
 #[cfg(feature = "num-rational")]
-pub extern crate num_rational;
+extern crate num_rational;
 
 #[cfg(feature = "num-bigint")]
 pub use num_bigint::{BigInt, BigUint};
@@ -84,14 +84,31 @@ pub use num_traits::{Num, Zero, One, Signed, Unsigned, Bounded,
 use std::ops::{Mul};
 
 #[cfg(feature = "num-bigint")]
-pub use num_bigint as bigint;
+pub mod bigint {
+    pub use num_bigint::*;
+}
+
 #[cfg(feature = "num-complex")]
-pub use num_complex as complex;
-pub use num_integer as integer;
-pub use num_iter as iter;
-pub use num_traits as traits;
+pub mod complex {
+    pub use num_complex::*;
+}
+
+pub mod integer {
+    pub use num_integer::*;
+}
+
+pub mod iter {
+    pub use num_iter::*;
+}
+
+pub mod traits {
+    pub use num_traits::*;
+}
+
 #[cfg(feature = "num-rational")]
-pub use num_rational as rational;
+pub mod rational {
+    pub use num_rational::*;
+}
 
 /// Returns the additive identity, `0`.
 #[inline(always)] pub fn zero<T: Zero>() -> T { Zero::zero() }


### PR DESCRIPTION
Rust 1.4 through 1.7 will issue warnings that `pub extern crate` does
not work as expected, although it appears to be fine.  But Rust 1.8 and
later issue `#[warn(private_in_public)]` for `pub use num_foo as foo` if
that crate isn't public, and that's headed toward a hard error.

@bluss suggested instead `pub mod foo { pub use num_foo::*; }`, which
I thought I had tried before, but it appears to work fine on all
versions of Rust.  Let's do it!

A small downside is that docs for `num::foo` now just show the wildcard
reexport, instead of direct documentation, but at least there's a link
to follow to the sub-crate.

It's a breaking change that `num::num_foo` paths are no longer public,
but we didn't really want those exposed in the first place.  I consider
this minor -- people should either use the `num::foo` module as before
the split-up, or use the `num_foo` crate directly.

Fixes #189.