### PR TITLE
`use serde;` leads to compilation error; `extern crate` is enough

### DIFF
--- a/complex/src/lib.rs
+++ b/complex/src/lib.rs
@@ -23,9 +23,6 @@ use std::fmt;
 use std::hash;
 use std::ops::{Add, Div, Mul, Neg, Sub};
 
-#[cfg(feature = "serde")]
-use serde;
-
 use traits::{Zero, One, Num, Float};
 
 // FIXME #1284: handle complex NaN & infinity etc. This


### PR DESCRIPTION
This PR fixes the compile error of `num-complex` that appears due to a redundant `use serde;` after `extern crate serde;` in the same module. To reproduce the error, just build `num-complex` with the feature `serde`, see below.

```zsh
% cargo build --features serde
   Compiling num-complex v0.1.32 (file:///home/janis/github/num/complex)
src/lib.rs:27:5: 27:10 error: an extern crate named `serde` has already been imported in this module [E0259]
src/lib.rs:27 use serde;
                  ^~~~~
src/lib.rs:19:1: 19:20 note: previous import of `serde` here
src/lib.rs:19 extern crate serde;
              ^~~~~~~~~~~~~~~~~~~
src/lib.rs:27:5: 27:10 help: run `rustc --explain E0259` to see a detailed explanation
error: aborting due to previous error
error: Could not compile `num-complex`.
```