### PR TITLE
bigint: simplify the add2/sub2 loops

### DIFF
--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -91,6 +91,16 @@ fn fib_100(b: &mut Bencher) {
 }
 
 #[bench]
+fn fib_1000(b: &mut Bencher) {
+    b.iter(|| fib(1000));
+}
+
+#[bench]
+fn fib_10000(b: &mut Bencher) {
+    b.iter(|| fib(10000));
+}
+
+#[bench]
 fn fac_to_string(b: &mut Bencher) {
     let fac = factorial(100);
     b.iter(|| fac.to_string());


### PR DESCRIPTION
This splits the main arithmetic loops from the final carry/borrow
propagation, and also normalizes the slice lengths before iteration.
This lets the optimizer generate better code for these functions.