### PR TITLE
bigint: allow `Sub` to work in-place on the RHS

### DIFF
--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -40,12 +40,25 @@ fn factorial(n: usize) -> BigUint {
     f
 }
 
+/// Compute Fibonacci numbers
 fn fib(n: usize) -> BigUint {
     let mut f0: BigUint = Zero::zero();
     let mut f1: BigUint = One::one();
     for _ in 0..n {
         let f2 = f0 + &f1;
         f0 = replace(&mut f1, f2);
+    }
+    f0
+}
+
+/// Compute Fibonacci numbers with two ops per iteration
+/// (add and subtract, like issue #200)
+fn fib2(n: usize) -> BigUint {
+    let mut f0: BigUint = Zero::zero();
+    let mut f1: BigUint = One::one();
+    for _ in 0..n {
+        f1 = f1 + &f0;
+        f0 = &f1 - f0;
     }
     f0
 }
@@ -98,6 +111,21 @@ fn fib_1000(b: &mut Bencher) {
 #[bench]
 fn fib_10000(b: &mut Bencher) {
     b.iter(|| fib(10000));
+}
+
+#[bench]
+fn fib2_100(b: &mut Bencher) {
+    b.iter(|| fib2(100));
+}
+
+#[bench]
+fn fib2_1000(b: &mut Bencher) {
+    b.iter(|| fib2(1000));
+}
+
+#[bench]
+fn fib2_10000(b: &mut Bencher) {
+    b.iter(|| fib2(10000));
 }
 
 #[bench]


### PR DESCRIPTION
A new Fibonacci benchmark demonstrates the improvement by using both
addition and subtraction in each iteration of the loop, like #200.

Before:

    test fib2_100          ... bench:       4,558 ns/iter (+/- 3,357)
    test fib2_1000         ... bench:      62,575 ns/iter (+/- 5,200)
    test fib2_10000        ... bench:   2,898,425 ns/iter (+/- 207,973)

After:

    test fib2_100          ... bench:       1,973 ns/iter (+/- 102)
    test fib2_1000         ... bench:      41,203 ns/iter (+/- 947)
    test fib2_10000        ... bench:   2,544,272 ns/iter (+/- 45,183)