### PR TITLE
Add `is_one` method to `One` trait.

### DIFF
--- a/bigint/src/bigint.rs
+++ b/bigint/src/bigint.rs
@@ -260,6 +260,11 @@ impl One for BigInt {
     fn one() -> BigInt {
         BigInt::from_biguint(Plus, One::one())
     }
+    
+    #[inline]
+    fn is_one(&self) -> bool {
+        self.sign == Plus && self.data.is_one()
+    }
 }
 
 impl Signed for BigInt {

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -368,6 +368,11 @@ impl One for BigUint {
     fn one() -> BigUint {
         BigUint::new(vec![1])
     }
+    
+    #[inline]
+    fn is_one(&self) -> bool {
+        self.data == [1]
+    }
 }
 
 impl Unsigned for BigUint {}

--- a/complex/src/lib.rs
+++ b/complex/src/lib.rs
@@ -613,7 +613,7 @@ impl<T: Clone + Num> One for Complex<T> {
     
     #[inline]
     fn is_one(&self) -> bool {
-        self.re == One::one() && self.im == Zero::zero()
+        self.re.is_one() && self.im.is_zero()
     }
 }
 

--- a/complex/src/lib.rs
+++ b/complex/src/lib.rs
@@ -610,6 +610,11 @@ impl<T: Clone + Num> One for Complex<T> {
     fn one() -> Complex<T> {
         Complex::new(One::one(), Zero::zero())
     }
+    
+    #[inline]
+    fn is_one(&self) -> bool {
+        self.re == One::one() && self.im == Zero::zero()
+    }
 }
 
 /* string conversions */

--- a/iter/src/lib.rs
+++ b/iter/src/lib.rs
@@ -313,6 +313,10 @@ mod tests {
             fn one() -> Foo {
                 Foo
             }
+            
+            fn is_one(&self) -> bool {
+                true
+            }
         }
 
         assert!(super::range(0, 5).collect::<Vec<isize>>() == vec![0, 1, 2, 3, 4]);

--- a/rational/src/lib.rs
+++ b/rational/src/lib.rs
@@ -476,6 +476,11 @@ impl<T: Clone + Integer> One for Ratio<T> {
     fn one() -> Ratio<T> {
         Ratio::new_raw(One::one(), One::one())
     }
+    
+    #[inline]
+    fn is_one(&self) -> bool {
+        self == &Ratio::one()
+    }
 }
 
 impl<T: Clone + Integer> Num for Ratio<T> {

--- a/rational/src/lib.rs
+++ b/rational/src/lib.rs
@@ -479,7 +479,7 @@ impl<T: Clone + Integer> One for Ratio<T> {
     
     #[inline]
     fn is_one(&self) -> bool {
-        self == &Ratio::one()
+        self.numer == self.denom
     }
 }
 

--- a/traits/src/identities.rs
+++ b/traits/src/identities.rs
@@ -68,6 +68,10 @@ pub trait One: Sized + Mul<Self, Output = Self> {
     /// `static mut`s.
     // FIXME (#5527): This should be an associated constant
     fn one() -> Self;
+
+    /// Returns `true` if `self` is equal to the multiplicative identity.
+    #[inline]
+    fn is_one(&self) -> bool;
 }
 
 macro_rules! one_impl {
@@ -75,6 +79,9 @@ macro_rules! one_impl {
         impl One for $t {
             #[inline]
             fn one() -> $t { $v }
+
+            #[inline]
+            fn is_one(&self) -> bool { *self == $v }    
         }
     }
 }


### PR DESCRIPTION
Implement `is_one` for all number types in crate.

Closes #214

BREAKING CHANGE: Implementors of `One` need to provide
a `is_one` method.
