### PR TITLE
Inline small functions, especially wrappers

### DIFF
--- a/bigint/src/bigint.rs
+++ b/bigint/src/bigint.rs
@@ -1068,6 +1068,7 @@ impl BigInt {
 
     /// Determines the fewest bits necessary to express the `BigInt`,
     /// not including the sign.
+    #[inline]
     pub fn bits(&self) -> usize {
         self.data.bits()
     }

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -1049,6 +1049,7 @@ impl BigUint {
     }
 
     /// Determines the fewest bits necessary to express the `BigUint`.
+    #[inline]
     pub fn bits(&self) -> usize {
         if self.is_zero() {
             return 0;

--- a/traits/src/bounds.rs
+++ b/traits/src/bounds.rs
@@ -55,9 +55,11 @@ macro_rules! for_each_tuple {
 macro_rules! bounded_tuple {
     ( $($name:ident)* ) => (
         impl<$($name: Bounded,)*> Bounded for ($($name,)*) {
+            #[inline]
             fn min_value() -> Self {
                 ($($name::min_value(),)*)
             }
+            #[inline]
             fn max_value() -> Self {
                 ($($name::max_value(),)*)
             }

--- a/traits/src/float.rs
+++ b/traits/src/float.rs
@@ -515,6 +515,7 @@ pub trait Float
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[inline]
     fn to_degrees(self) -> Self {
         let halfpi = Self::zero().acos();
         let ninety = Self::from(90u8).unwrap();
@@ -532,6 +533,7 @@ pub trait Float
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[inline]
     fn to_radians(self) -> Self {
         let halfpi = Self::zero().acos();
         let ninety = Self::from(90u8).unwrap();
@@ -904,231 +906,287 @@ pub trait Float
 macro_rules! float_impl {
     ($T:ident $decode:ident) => (
         impl Float for $T {
+            #[inline]
             fn nan() -> Self {
                 ::std::$T::NAN
             }
 
+            #[inline]
             fn infinity() -> Self {
                 ::std::$T::INFINITY
             }
 
+            #[inline]
             fn neg_infinity() -> Self {
                 ::std::$T::NEG_INFINITY
             }
 
+            #[inline]
             fn neg_zero() -> Self {
                 -0.0
             }
 
+            #[inline]
             fn min_value() -> Self {
                 ::std::$T::MIN
             }
 
+            #[inline]
             fn min_positive_value() -> Self {
                 ::std::$T::MIN_POSITIVE
             }
 
+            #[inline]
             fn max_value() -> Self {
                 ::std::$T::MAX
             }
 
+            #[inline]
             fn is_nan(self) -> bool {
                 <$T>::is_nan(self)
             }
 
+            #[inline]
             fn is_infinite(self) -> bool {
                 <$T>::is_infinite(self)
             }
 
+            #[inline]
             fn is_finite(self) -> bool {
                 <$T>::is_finite(self)
             }
 
+            #[inline]
             fn is_normal(self) -> bool {
                 <$T>::is_normal(self)
             }
 
+            #[inline]
             fn classify(self) -> FpCategory {
                 <$T>::classify(self)
             }
 
+            #[inline]
             fn floor(self) -> Self {
                 <$T>::floor(self)
             }
 
+            #[inline]
             fn ceil(self) -> Self {
                 <$T>::ceil(self)
             }
 
+            #[inline]
             fn round(self) -> Self {
                 <$T>::round(self)
             }
 
+            #[inline]
             fn trunc(self) -> Self {
                 <$T>::trunc(self)
             }
 
+            #[inline]
             fn fract(self) -> Self {
                 <$T>::fract(self)
             }
 
+            #[inline]
             fn abs(self) -> Self {
                 <$T>::abs(self)
             }
 
+            #[inline]
             fn signum(self) -> Self {
                 <$T>::signum(self)
             }
 
+            #[inline]
             fn is_sign_positive(self) -> bool {
                 <$T>::is_sign_positive(self)
             }
 
+            #[inline]
             fn is_sign_negative(self) -> bool {
                 <$T>::is_sign_negative(self)
             }
 
+            #[inline]
             fn mul_add(self, a: Self, b: Self) -> Self {
                 <$T>::mul_add(self, a, b)
             }
 
+            #[inline]
             fn recip(self) -> Self {
                 <$T>::recip(self)
             }
 
+            #[inline]
             fn powi(self, n: i32) -> Self {
                 <$T>::powi(self, n)
             }
 
+            #[inline]
             fn powf(self, n: Self) -> Self {
                 <$T>::powf(self, n)
             }
 
+            #[inline]
             fn sqrt(self) -> Self {
                 <$T>::sqrt(self)
             }
 
+            #[inline]
             fn exp(self) -> Self {
                 <$T>::exp(self)
             }
 
+            #[inline]
             fn exp2(self) -> Self {
                 <$T>::exp2(self)
             }
 
+            #[inline]
             fn ln(self) -> Self {
                 <$T>::ln(self)
             }
 
+            #[inline]
             fn log(self, base: Self) -> Self {
                 <$T>::log(self, base)
             }
 
+            #[inline]
             fn log2(self) -> Self {
                 <$T>::log2(self)
             }
 
+            #[inline]
             fn log10(self) -> Self {
                 <$T>::log10(self)
             }
 
+            #[inline]
             fn to_degrees(self) -> Self {
                 // NB: `f32` didn't stabilize this until 1.7
                 // <$T>::to_degrees(self)
                 self * (180. / ::std::$T::consts::PI)
             }
 
+            #[inline]
             fn to_radians(self) -> Self {
                 // NB: `f32` didn't stabilize this until 1.7
                 // <$T>::to_radians(self)
                 self * (::std::$T::consts::PI / 180.)
             }
 
+            #[inline]
             fn max(self, other: Self) -> Self {
                 <$T>::max(self, other)
             }
 
+            #[inline]
             fn min(self, other: Self) -> Self {
                 <$T>::min(self, other)
             }
 
+            #[inline]
             #[allow(deprecated)]
             fn abs_sub(self, other: Self) -> Self {
                 <$T>::abs_sub(self, other)
             }
 
+            #[inline]
             fn cbrt(self) -> Self {
                 <$T>::cbrt(self)
             }
 
+            #[inline]
             fn hypot(self, other: Self) -> Self {
                 <$T>::hypot(self, other)
             }
 
+            #[inline]
             fn sin(self) -> Self {
                 <$T>::sin(self)
             }
 
+            #[inline]
             fn cos(self) -> Self {
                 <$T>::cos(self)
             }
 
+            #[inline]
             fn tan(self) -> Self {
                 <$T>::tan(self)
             }
 
+            #[inline]
             fn asin(self) -> Self {
                 <$T>::asin(self)
             }
 
+            #[inline]
             fn acos(self) -> Self {
                 <$T>::acos(self)
             }
 
+            #[inline]
             fn atan(self) -> Self {
                 <$T>::atan(self)
             }
 
+            #[inline]
             fn atan2(self, other: Self) -> Self {
                 <$T>::atan2(self, other)
             }
 
+            #[inline]
             fn sin_cos(self) -> (Self, Self) {
                 <$T>::sin_cos(self)
             }
 
+            #[inline]
             fn exp_m1(self) -> Self {
                 <$T>::exp_m1(self)
             }
 
+            #[inline]
             fn ln_1p(self) -> Self {
                 <$T>::ln_1p(self)
             }
 
+            #[inline]
             fn sinh(self) -> Self {
                 <$T>::sinh(self)
             }
 
+            #[inline]
             fn cosh(self) -> Self {
                 <$T>::cosh(self)
             }
 
+            #[inline]
             fn tanh(self) -> Self {
                 <$T>::tanh(self)
             }
 
+            #[inline]
             fn asinh(self) -> Self {
                 <$T>::asinh(self)
             }
 
+            #[inline]
             fn acosh(self) -> Self {
                 <$T>::acosh(self)
             }
 
+            #[inline]
             fn atanh(self) -> Self {
                 <$T>::atanh(self)
             }
 
+            #[inline]
             fn integer_decode(self) -> (u64, i16, i8) {
                 $decode(self)
             }

--- a/traits/src/int.rs
+++ b/traits/src/int.rs
@@ -280,66 +280,82 @@ pub trait PrimInt
 macro_rules! prim_int_impl {
     ($T:ty, $S:ty, $U:ty) => (
         impl PrimInt for $T {
+            #[inline]
             fn count_ones(self) -> u32 {
                 <$T>::count_ones(self)
             }
 
+            #[inline]
             fn count_zeros(self) -> u32 {
                 <$T>::count_zeros(self)
             }
 
+            #[inline]
             fn leading_zeros(self) -> u32 {
                 <$T>::leading_zeros(self)
             }
 
+            #[inline]
             fn trailing_zeros(self) -> u32 {
                 <$T>::trailing_zeros(self)
             }
 
+            #[inline]
             fn rotate_left(self, n: u32) -> Self {
                 <$T>::rotate_left(self, n)
             }
 
+            #[inline]
             fn rotate_right(self, n: u32) -> Self {
                 <$T>::rotate_right(self, n)
             }
 
+            #[inline]
             fn signed_shl(self, n: u32) -> Self {
                 ((self as $S) << n) as $T
             }
 
+            #[inline]
             fn signed_shr(self, n: u32) -> Self {
                 ((self as $S) >> n) as $T
             }
 
+            #[inline]
             fn unsigned_shl(self, n: u32) -> Self {
                 ((self as $U) << n) as $T
             }
 
+            #[inline]
             fn unsigned_shr(self, n: u32) -> Self {
                 ((self as $U) >> n) as $T
             }
 
+            #[inline]
             fn swap_bytes(self) -> Self {
                 <$T>::swap_bytes(self)
             }
 
+            #[inline]
             fn from_be(x: Self) -> Self {
                 <$T>::from_be(x)
             }
 
+            #[inline]
             fn from_le(x: Self) -> Self {
                 <$T>::from_le(x)
             }
 
+            #[inline]
             fn to_be(self) -> Self {
                 <$T>::to_be(self)
             }
 
+            #[inline]
             fn to_le(self) -> Self {
                 <$T>::to_le(self)
             }
 
+            #[inline]
             fn pow(self, exp: u32) -> Self {
                 <$T>::pow(self, exp)
             }

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -46,6 +46,7 @@ macro_rules! int_trait_impl {
     ($name:ident for $($t:ty)*) => ($(
         impl $name for $t {
             type FromStrRadixErr = ::std::num::ParseIntError;
+            #[inline]
             fn from_str_radix(s: &str, radix: u32)
                               -> Result<Self, ::std::num::ParseIntError>
             {

--- a/traits/src/ops/saturating.rs
+++ b/traits/src/ops/saturating.rs
@@ -12,10 +12,12 @@ pub trait Saturating {
 macro_rules! saturating_impl {
     ($trait_name:ident for $($t:ty)*) => {$(
         impl $trait_name for $t {
+            #[inline]
             fn saturating_add(self, v: Self) -> Self {
                 Self::saturating_add(self, v)
             }
 
+            #[inline]
             fn saturating_sub(self, v: Self) -> Self {
                 Self::saturating_sub(self, v)
             }


### PR DESCRIPTION
We already had `#[inline]` throughout a lot of the code, but notably some
functions which simply wrap inherent methods were not inlined.  That means
external references will get a full function call, when they could have been
optimized to as little as one opcode.

This PR inlines all functions that look tiny enough for this to matter.

Fixes #218.