### PR TITLE
Use serde 0.8

### DIFF
--- a/.travis/test_nightly.sh
+++ b/.travis/test_nightly.sh
@@ -5,3 +5,6 @@ set -ex
 cargo bench --verbose
 
 cargo test --verbose --manifest-path=macros/Cargo.toml
+
+# Build test for the serde feature
+cargo build --verbose --features "serde"

--- a/.travis/test_nightly.sh
+++ b/.travis/test_nightly.sh
@@ -8,3 +8,7 @@ cargo test --verbose --manifest-path=macros/Cargo.toml
 
 # Build test for the serde feature
 cargo build --verbose --features "serde"
+
+# Downgrade serde and build test the 0.7.0 channel as well
+cargo update -p serde --precise 0.7.0
+cargo build --verbose --features "serde"

--- a/bigint/Cargo.toml
+++ b/bigint/Cargo.toml
@@ -29,7 +29,7 @@ version = "0.3.19"
 
 [dependencies.serde]
 optional = true
-version = "0.7.0"
+version = ">= 0.7.0, < 0.9.0"
 
 [features]
 default = ["rand", "rustc-serialize"]

--- a/complex/Cargo.toml
+++ b/complex/Cargo.toml
@@ -22,7 +22,7 @@ version = "0.3.19"
 
 [dependencies.serde]
 optional = true
-version = "^0.7.0"
+version = ">= 0.7.0, < 0.9.0"
 
 [features]
 default = ["rustc-serialize"]

--- a/rational/Cargo.toml
+++ b/rational/Cargo.toml
@@ -30,7 +30,7 @@ version = "0.3.19"
 
 [dependencies.serde]
 optional = true
-version = "0.7.0"
+version = ">= 0.7.0, < 0.9.0"
 
 [features]
 default = ["bigint", "rustc-serialize"]

--- a/rational/src/lib.rs
+++ b/rational/src/lib.rs
@@ -601,7 +601,7 @@ impl<T> serde::Deserialize for Ratio<T>
     fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
         where D: serde::Deserializer
     {
-        let (numer, denom) = try!(serde::Deserialize::deserialize(deserializer));
+        let (numer, denom): (T,T) = try!(serde::Deserialize::deserialize(deserializer));
         if denom.is_zero() {
             Err(serde::de::Error::invalid_value("denominator is zero"))
         } else {

--- a/rational/src/lib.rs
+++ b/rational/src/lib.rs
@@ -28,9 +28,6 @@ use std::hash;
 use std::ops::{Add, Div, Mul, Neg, Rem, Sub};
 use std::str::FromStr;
 
-#[cfg(feature = "serde")]
-use serde;
-
 #[cfg(feature = "num-bigint")]
 use bigint::{BigInt, BigUint, Sign};
 


### PR DESCRIPTION
I updated `bigint`, `complex`, and `rational` to use `serde 0.8`, and also fixed deserialization and the `serde` feature as such in the `rational` crate (didn't add any tests, but it compiles now).

Similar to https://github.com/rust-num/num/pull/196 for `num/complex`, “`use serde;`” needed to be removed in `num/rational`.