### PR TITLE
Fix import serde and rational deserialization

### DIFF
--- a/.travis/test_nightly.sh
+++ b/.travis/test_nightly.sh
@@ -5,3 +5,6 @@ set -ex
 cargo bench --verbose
 
 cargo test --verbose --manifest-path=macros/Cargo.toml
+
+# Build test for the serde feature
+cargo build --verbose --features "serde"

--- a/rational/src/lib.rs
+++ b/rational/src/lib.rs
@@ -601,7 +601,7 @@ impl<T> serde::Deserialize for Ratio<T>
     fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
         where D: serde::Deserializer
     {
-        let (numer, denom) = try!(serde::Deserialize::deserialize(deserializer));
+        let (numer, denom): (T,T) = try!(serde::Deserialize::deserialize(deserializer));
         if denom.is_zero() {
             Err(serde::de::Error::invalid_value("denominator is zero"))
         } else {

--- a/rational/src/lib.rs
+++ b/rational/src/lib.rs
@@ -28,9 +28,6 @@ use std::hash;
 use std::ops::{Add, Div, Mul, Neg, Rem, Sub};
 use std::str::FromStr;
 
-#[cfg(feature = "serde")]
-use serde;
-
 #[cfg(feature = "num-bigint")]
 use bigint::{BigInt, BigUint, Sign};
 


### PR DESCRIPTION
Similar to #196 for num/complex, “use serde;” needed to be removed in num/rational.

Also, deserialization of `num/rational` needed to be fixed by adding type annotations.

This is in response to https://github.com/rust-num/num/pull/222#issuecomment-239957062 of issue https://github.com/rust-num/num/pull/222.

Also added a travis line, in response to https://github.com/rust-num/num/pull/222#issuecomment-239957062. Hope it works.