### PR TITLE
Fix num-macros for nightly

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -108,6 +108,7 @@ pub fn expand_deriving_from_primitive(cx: &mut ExtCtxt,
             }
         ),
         associated_types: Vec::new(),
+        supports_unions: false,
     };
 
     trait_def.expand(cx, mitem, &item, push)


### PR DESCRIPTION
Now compatible with rustc 1.13.0-nightly (32571c05c 2016-09-17)