### PR TITLE
Implementing epsilon function to retrieve EPSILON constant

### DIFF
--- a/traits/src/float.rs
+++ b/traits/src/float.rs
@@ -2,6 +2,9 @@ use std::mem;
 use std::ops::Neg;
 use std::num::FpCategory;
 
+// Used for default implementation of `epsilon`
+use std::f32;
+
 use {Num, NumCast};
 
 // FIXME: these doctests aren't actually helpful, because they're using and
@@ -99,7 +102,14 @@ pub trait Float
     ///
     /// assert_eq!(x, f64::EPSILON);
     /// ```
-    fn epsilon() -> Self;
+    ///
+    /// # Panics
+    ///
+    /// The default implementation will panic if `f32::EPSILON` cannot
+    /// be cast to `Self`.
+    fn epsilon() -> Self {
+        Self::from(f32::EPSILON).expect("Unable to cast from f32::EPSILON")
+    }
 
     /// Returns the largest finite value that this type can represent.
     ///

--- a/traits/src/float.rs
+++ b/traits/src/float.rs
@@ -89,6 +89,18 @@ pub trait Float
     /// ```
     fn min_positive_value() -> Self;
 
+    /// Returns epsilon, a small positive value.
+    ///
+    /// ```
+    /// use num_traits::Float;
+    /// use std::f64;
+    ///
+    /// let x: f64 = Float::epsilon();
+    ///
+    /// assert_eq!(x, f64::EPSILON);
+    /// ```
+    fn epsilon() -> Self;
+
     /// Returns the largest finite value that this type can represent.
     ///
     /// ```
@@ -934,6 +946,11 @@ macro_rules! float_impl {
             #[inline]
             fn min_positive_value() -> Self {
                 ::std::$T::MIN_POSITIVE
+            }
+
+            #[inline]
+            fn epsilon() -> Self {
+                ::std::$T::EPSILON
             }
 
             #[inline]


### PR DESCRIPTION
Hey!

This PR exposes a new `epsilon` function in the `Float` trait so that users can access the `EPSILON` constant on the float types. I figured as this was such a minimal change it was easier to get a PR in offering the change then write up an issue.

For me this is a valuable addition. When writing linear algebra or other optimization routines with generic floats we often want to check if some stopping criteria is reached, often something like: `(a - b).abs() < eps`. Having access to a standard _small value_ would make this a little easier.