### PR TITLE
traits: Remove pattern in trait's method signature

### DIFF
--- a/traits/src/int.rs
+++ b/traits/src/int.rs
@@ -274,7 +274,7 @@ pub trait PrimInt
     ///
     /// assert_eq!(2i32.pow(4), 16);
     /// ```
-    fn pow(self, mut exp: u32) -> Self;
+    fn pow(self, exp: u32) -> Self;
 }
 
 macro_rules! prim_int_impl {


### PR DESCRIPTION
This use of `mut` was nonsensical for now, but is proposed to be
disallowed by rustc in the future (as a bugfix).

See rust-lang/rust/pull/37378 for context.