### PR TITLE
Add doc(html_root_url) and other doc attrs to each crate

### DIFF
--- a/bigint/src/lib.rs
+++ b/bigint/src/lib.rs
@@ -72,7 +72,7 @@
 #![doc(html_logo_url = "https://rust-num.github.io/num/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://rust-num.github.io/num/favicon.ico",
        html_root_url = "https://rust-num.github.io/num/",
-       html_playground_url = "https://play.rust-lang.org/")]
+       html_playground_url = "http://play.integer32.com/")]
 
 #[cfg(any(feature = "rand", test))]
 extern crate rand;

--- a/bigint/src/lib.rs
+++ b/bigint/src/lib.rs
@@ -69,6 +69,10 @@
 //! # fn main() {
 //! # }
 //! ```
+#![doc(html_logo_url = "https://rust-num.github.io/num/rust-logo-128x128-blk-v2.png",
+       html_favicon_url = "https://rust-num.github.io/num/favicon.ico",
+       html_root_url = "https://rust-num.github.io/num/",
+       html_playground_url = "https://play.rust-lang.org/")]
 
 #[cfg(any(feature = "rand", test))]
 extern crate rand;

--- a/complex/src/lib.rs
+++ b/complex/src/lib.rs
@@ -9,6 +9,10 @@
 // except according to those terms.
 
 //! Complex numbers.
+#![doc(html_logo_url = "https://rust-num.github.io/num/rust-logo-128x128-blk-v2.png",
+       html_favicon_url = "https://rust-num.github.io/num/favicon.ico",
+       html_root_url = "https://rust-num.github.io/num/",
+       html_playground_url = "https://play.rust-lang.org/")]
 
 extern crate num_traits as traits;
 

--- a/complex/src/lib.rs
+++ b/complex/src/lib.rs
@@ -12,7 +12,7 @@
 #![doc(html_logo_url = "https://rust-num.github.io/num/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://rust-num.github.io/num/favicon.ico",
        html_root_url = "https://rust-num.github.io/num/",
-       html_playground_url = "https://play.rust-lang.org/")]
+       html_playground_url = "http://play.integer32.com/")]
 
 extern crate num_traits as traits;
 

--- a/integer/src/lib.rs
+++ b/integer/src/lib.rs
@@ -12,7 +12,7 @@
 #![doc(html_logo_url = "https://rust-num.github.io/num/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://rust-num.github.io/num/favicon.ico",
        html_root_url = "https://rust-num.github.io/num/",
-       html_playground_url = "https://play.rust-lang.org/")]
+       html_playground_url = "http://play.integer32.com/")]
 
 extern crate num_traits as traits;
 

--- a/integer/src/lib.rs
+++ b/integer/src/lib.rs
@@ -9,6 +9,10 @@
 // except according to those terms.
 
 //! Integer trait and functions.
+#![doc(html_logo_url = "https://rust-num.github.io/num/rust-logo-128x128-blk-v2.png",
+       html_favicon_url = "https://rust-num.github.io/num/favicon.ico",
+       html_root_url = "https://rust-num.github.io/num/",
+       html_playground_url = "https://play.rust-lang.org/")]
 
 extern crate num_traits as traits;
 

--- a/iter/src/lib.rs
+++ b/iter/src/lib.rs
@@ -12,7 +12,7 @@
 #![doc(html_logo_url = "https://rust-num.github.io/num/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://rust-num.github.io/num/favicon.ico",
        html_root_url = "https://rust-num.github.io/num/",
-       html_playground_url = "https://play.rust-lang.org/")]
+       html_playground_url = "http://play.integer32.com/")]
 
 extern crate num_traits as traits;
 extern crate num_integer as integer;

--- a/iter/src/lib.rs
+++ b/iter/src/lib.rs
@@ -9,6 +9,10 @@
 // except according to those terms.
 
 //! External iterators for generic mathematics
+#![doc(html_logo_url = "https://rust-num.github.io/num/rust-logo-128x128-blk-v2.png",
+       html_favicon_url = "https://rust-num.github.io/num/favicon.ico",
+       html_root_url = "https://rust-num.github.io/num/",
+       html_playground_url = "https://play.rust-lang.org/")]
 
 extern crate num_traits as traits;
 extern crate num_integer as integer;

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -12,7 +12,7 @@
 #![doc(html_logo_url = "https://rust-num.github.io/num/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://rust-num.github.io/num/favicon.ico",
        html_root_url = "https://rust-num.github.io/num/",
-       html_playground_url = "https://play.rust-lang.org/")]
+       html_playground_url = "http://play.integer32.com/")]
 
 extern crate syntax;
 extern crate syntax_ext;

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -9,6 +9,10 @@
 // except according to those terms.
 
 #![feature(plugin_registrar, rustc_private)]
+#![doc(html_logo_url = "https://rust-num.github.io/num/rust-logo-128x128-blk-v2.png",
+       html_favicon_url = "https://rust-num.github.io/num/favicon.ico",
+       html_root_url = "https://rust-num.github.io/num/",
+       html_playground_url = "https://play.rust-lang.org/")]
 
 extern crate syntax;
 extern crate syntax_ext;

--- a/rational/src/lib.rs
+++ b/rational/src/lib.rs
@@ -12,7 +12,7 @@
 #![doc(html_logo_url = "https://rust-num.github.io/num/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://rust-num.github.io/num/favicon.ico",
        html_root_url = "https://rust-num.github.io/num/",
-       html_playground_url = "https://play.rust-lang.org/")]
+       html_playground_url = "http://play.integer32.com/")]
 
 #[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;

--- a/rational/src/lib.rs
+++ b/rational/src/lib.rs
@@ -9,6 +9,10 @@
 // except according to those terms.
 
 //! Rational numbers
+#![doc(html_logo_url = "https://rust-num.github.io/num/rust-logo-128x128-blk-v2.png",
+       html_favicon_url = "https://rust-num.github.io/num/favicon.ico",
+       html_root_url = "https://rust-num.github.io/num/",
+       html_playground_url = "https://play.rust-lang.org/")]
 
 #[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 #![doc(html_logo_url = "https://rust-num.github.io/num/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://rust-num.github.io/num/favicon.ico",
        html_root_url = "https://rust-num.github.io/num/",
-       html_playground_url = "https://play.rust-lang.org/")]
+       html_playground_url = "http://play.integer32.com/")]
 
 extern crate num_traits;
 extern crate num_integer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,10 +52,10 @@
 //! ```
 //!
 //! [newt]: https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Babylonian_method
-#![doc(html_logo_url = "http://rust-num.github.io/num/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "http://rust-num.github.io/num/favicon.ico",
-       html_root_url = "http://rust-num.github.io/num/",
-       html_playground_url = "http://play.rust-lang.org/")]
+#![doc(html_logo_url = "https://rust-num.github.io/num/rust-logo-128x128-blk-v2.png",
+       html_favicon_url = "https://rust-num.github.io/num/favicon.ico",
+       html_root_url = "https://rust-num.github.io/num/",
+       html_playground_url = "https://play.rust-lang.org/")]
 
 extern crate num_traits;
 extern crate num_integer;

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -12,7 +12,7 @@
 #![doc(html_logo_url = "https://rust-num.github.io/num/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://rust-num.github.io/num/favicon.ico",
        html_root_url = "https://rust-num.github.io/num/",
-       html_playground_url = "https://play.rust-lang.org/")]
+       html_playground_url = "http://play.integer32.com/")]
 
 use std::ops::{Add, Sub, Mul, Div, Rem};
 

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -9,6 +9,10 @@
 // except according to those terms.
 
 //! Numeric traits for generic mathematics
+#![doc(html_logo_url = "https://rust-num.github.io/num/rust-logo-128x128-blk-v2.png",
+       html_favicon_url = "https://rust-num.github.io/num/favicon.ico",
+       html_root_url = "https://rust-num.github.io/num/",
+       html_playground_url = "https://play.rust-lang.org/")]
 
 use std::ops::{Add, Sub, Mul, Div, Rem};
 


### PR DESCRIPTION
Also update to use https instead of http. This avoids mixed content
degradation on docs.rs.

The doc root URLs are correct as they are, the URL does not include the
crate name itself.