### PR TITLE
rational: test_recip_fail: Correct should_panic syntax

### DIFF
--- a/rational/src/lib.rs
+++ b/rational/src/lib.rs
@@ -1048,7 +1048,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic = "== 0"]
+    #[should_panic(expected = "== 0")]
     fn test_recip_fail() {
         let _a = Ratio::new(0, 1).recip();
     }


### PR DESCRIPTION
Fixes this warning with rustc nightly:

```
warning: attribute must be of the form: `#[should_panic]` or `#[should_panic(expected = "error message")]`
    --> rational/src/lib.rs:1051:7
     |
1051 |     #[should_panic = "== 0"]
     |       ^^^^^^^^^^^^^^^^^^^^^
     |
     = note: Errors in this attribute were erroneously allowed and will become a hard error in a future release.
```
