### PR TITLE
Add clamp function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub use num_traits::{Num, Zero, One, Signed, Unsigned, Bounded,
                      one, zero, abs, abs_sub, signum,
                      Saturating, CheckedAdd, CheckedSub, CheckedMul, CheckedDiv,
                      PrimInt, Float, ToPrimitive, FromPrimitive, NumCast, cast,
-                     pow, checked_pow};
+                     pow, checked_pow, clamp};
 
 #[cfg(feature = "num-bigint")]
 pub mod bigint {
@@ -108,16 +108,4 @@ pub mod traits {
 #[cfg(feature = "num-rational")]
 pub mod rational {
     pub use num_rational::*;
-}
-
-/// A value bounded by a minimum and a maximum
-///
-/// If input is less than min then min is returned, if input is greater than max then max is
-/// returned.  Otherwise input is returned.
-#[inline]
-pub fn clamp<T: PartialOrd + Copy>(input: T, min: T, max: T) -> T {
-    debug_assert!(min < max, "min must be less than max");
-    if input <= min {min}
-    else if input >= max {max}
-    else {input}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@ pub mod rational {
 ///
 /// If input is less than min then min is returned, if input is greater than max then max is
 /// returned.  Otherwise input is returned.
+#[inline]
 pub fn clamp<T: PartialOrd + Copy>(input: T, min: T, max: T) -> T {
     debug_assert!(min < max, "min must be less than max");
     if input <= min {min}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,10 @@ pub mod traits {
 pub mod rational {
     pub use num_rational::*;
 }
-
+/// A value bounded by a minimum and a maximum
+///
+/// If input is less than min then min is returned, if input is greater than max then max is
+/// returned.  Otherwise input is returned.
 pub fn clamp<T: PartialOrd + Copy>(input: T, min: T, max: T) -> T {
     debug_assert!(min < max, "min must be less than max");
     if input <= min {min}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,3 +109,10 @@ pub mod traits {
 pub mod rational {
     pub use num_rational::*;
 }
+
+pub fn clamp<T: PartialOrd + Copy>(input: T, min: T, max: T) -> T {
+    debug_assert!(min < max, "min must be less than max");
+    if input < min {min}
+    else if input > max {max}
+    else {input}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ pub mod rational {
 
 pub fn clamp<T: PartialOrd + Copy>(input: T, min: T, max: T) -> T {
     debug_assert!(min < max, "min must be less than max");
-    if input < min {min}
-    else if input > max {max}
+    if input <= min {min}
+    else if input >= max {max}
     else {input}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,7 @@ pub mod traits {
 pub mod rational {
     pub use num_rational::*;
 }
+
 /// A value bounded by a minimum and a maximum
 ///
 /// If input is less than min then min is returned, if input is greater than max then max is

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -241,6 +241,35 @@ macro_rules! float_trait_impl {
 }
 float_trait_impl!(Num for f32 f64);
 
+/// A value bounded by a minimum and a maximum
+///
+/// If input is less than min then min is returned, if input is greater than max then max is
+/// returned.  Otherwise input is returned.
+#[inline]
+pub fn clamp<T: PartialOrd>(input: T, min: T, max: T) -> T {
+    debug_assert!(min <= max, "min must be less than max");
+    if input < min {
+        min
+    } else if input > max {
+        max
+    } else {
+        input
+    }
+}
+
+#[test]
+fn clamp_test() {
+    // Int test
+    assert_eq!(1, clamp(1, -1, 2));
+    assert_eq!(-1, clamp(-2, -1, 2));
+    assert_eq!(2, clamp(3, -1, 2));
+
+    // Float test
+    assert_eq!(1.0, clamp(1.0, -1.0, 2.0));
+    assert_eq!(-1.0, clamp(-2.0, -1.0, 2.0));
+    assert_eq!(2.0, clamp(3.0, -1.0, 2.0));
+}
+
 #[test]
 fn from_str_radix_unwrap() {
     // The Result error must impl Debug to allow unwrap()

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -247,7 +247,7 @@ float_trait_impl!(Num for f32 f64);
 /// returned.  Otherwise input is returned.
 #[inline]
 pub fn clamp<T: PartialOrd>(input: T, min: T, max: T) -> T {
-    debug_assert!(min <= max, "min must be less than max");
+    debug_assert!(min <= max, "min must be less than or equal to max");
     if input < min {
         min
     } else if input > max {

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -243,8 +243,9 @@ float_trait_impl!(Num for f32 f64);
 
 /// A value bounded by a minimum and a maximum
 ///
-/// If input is less than min then min is returned, if input is greater than max then max is
-/// returned.  Otherwise input is returned.
+///  If input is less than min then this returns min. 
+///  If input is greater than max then this returns max.  
+///  Otherwise this returns input. 
 #[inline]
 pub fn clamp<T: PartialOrd>(input: T, min: T, max: T) -> T {
     debug_assert!(min <= max, "min must be less than or equal to max");


### PR DESCRIPTION
This PR adds a "clamp" function to num.  Oftentimes it is desirable to restrict a value to between a certain minimum and maximum, the clamp function provides a generic way to do this.