### PR TITLE
bigint: Create the parsing error better for nested `+`

### DIFF
--- a/bigint/src/bigint.rs
+++ b/bigint/src/bigint.rs
@@ -3,8 +3,7 @@ use std::ops::{Add, Div, Mul, Neg, Rem, Shl, Shr, Sub};
 use std::str::{self, FromStr};
 use std::fmt;
 use std::cmp::Ordering::{self, Less, Greater, Equal};
-use std::{f32, f64};
-use std::{u8, i64, u64};
+use std::{i64, u64};
 use std::ascii::AsciiExt;
 
 #[cfg(feature = "serde")]

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::cmp;
 use std::cmp::Ordering::{self, Less, Greater, Equal};
 use std::{f32, f64};
-use std::{u8, i64, u64};
+use std::{u8, u64};
 use std::ascii::AsciiExt;
 
 #[cfg(feature = "serde")]

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -242,7 +242,9 @@ impl Num for BigUint {
                 v.push(d);
             } else {
                 // create ParseIntError::InvalidDigit
-                let e = u64::from_str_radix(&s[v.len()..], radix).unwrap_err();
+                // Include the previous character for context.
+                let i = cmp::max(v.len(), 1) - 1;
+                let e = u64::from_str_radix(&s[i..], radix).unwrap_err();
                 return Err(e.into());
             }
         }

--- a/bigint/src/tests/biguint.rs
+++ b/bigint/src/tests/biguint.rs
@@ -1041,6 +1041,8 @@ fn test_from_str_radix() {
     assert_eq!(plus_plus_one, None);
     let minus_one = BigUint::from_str_radix("-1", 10).ok();
     assert_eq!(minus_one, None);
+    let zero_plus_two = BigUint::from_str_radix("0+2", 10).ok();
+    assert_eq!(zero_plus_two, None);
 }
 
 #[test]


### PR DESCRIPTION
If a `+` is encountered in the middle of parsing a BigUint, this should
generate an `ParseIntError::InvalidDigit`.  Since we can't create that
directly, we get it by trying to parse a `u64` from this point, but of
course `+` is a perfectly valid prefix to a `u64`.

Now we include the previous character in the string passed to `u64`, so it
has proper parsing context to understand what's in error.

Fixes #268.