### PR TITLE
Replace deprecated Hasher

### DIFF
--- a/bigint/src/lib.rs
+++ b/bigint/src/lib.rs
@@ -121,7 +121,7 @@ use std::hash;
 #[cfg(test)]
 fn hash<T: hash::Hash>(x: &T) -> u64 {
     use std::hash::Hasher;
-    let mut hasher = hash::SipHasher::new();
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
     x.hash(&mut hasher);
     hasher.finish()
 }

--- a/complex/src/lib.rs
+++ b/complex/src/lib.rs
@@ -766,7 +766,7 @@ impl<T> serde::Deserialize for Complex<T> where
 #[cfg(test)]
 fn hash<T: hash::Hash>(x: &T) -> u64 {
     use std::hash::Hasher;
-    let mut hasher = hash::SipHasher::new();
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
     x.hash(&mut hasher);
     hasher.finish()
 }

--- a/rational/src/lib.rs
+++ b/rational/src/lib.rs
@@ -671,7 +671,7 @@ impl RatioErrorKind {
 #[cfg(test)]
 fn hash<T: hash::Hash>(x: &T) -> u64 {
     use std::hash::Hasher;
-    let mut hasher = hash::SipHasher::new();
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
     x.hash(&mut hasher);
     hasher.finish()
 }


### PR DESCRIPTION
`std::hash::SipHasher` is now deprecated, see https://doc.rust-lang.org/std/hash/struct.SipHasher.html 