### PR TITLE
Get the default hasher indirectly

### DIFF
--- a/bigint/src/lib.rs
+++ b/bigint/src/lib.rs
@@ -120,8 +120,9 @@ use std::hash;
 
 #[cfg(test)]
 fn hash<T: hash::Hash>(x: &T) -> u64 {
-    use std::hash::Hasher;
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    use std::hash::{BuildHasher, Hasher};
+    use std::collections::hash_map::RandomState;
+    let mut hasher = <RandomState as BuildHasher>::Hasher::new();
     x.hash(&mut hasher);
     hasher.finish()
 }

--- a/bigint/src/lib.rs
+++ b/bigint/src/lib.rs
@@ -121,7 +121,7 @@ use std::hash;
 #[cfg(test)]
 fn hash<T: hash::Hash>(x: &T) -> u64 {
     use std::hash::Hasher;
-    let mut hasher = hash::SipHasher::new();
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
     x.hash(&mut hasher);
     hasher.finish()
 }

--- a/complex/src/lib.rs
+++ b/complex/src/lib.rs
@@ -766,7 +766,7 @@ impl<T> serde::Deserialize for Complex<T> where
 #[cfg(test)]
 fn hash<T: hash::Hash>(x: &T) -> u64 {
     use std::hash::Hasher;
-    let mut hasher = hash::SipHasher::new();
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
     x.hash(&mut hasher);
     hasher.finish()
 }

--- a/complex/src/lib.rs
+++ b/complex/src/lib.rs
@@ -765,8 +765,9 @@ impl<T> serde::Deserialize for Complex<T> where
 
 #[cfg(test)]
 fn hash<T: hash::Hash>(x: &T) -> u64 {
-    use std::hash::Hasher;
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    use std::hash::{BuildHasher, Hasher};
+    use std::collections::hash_map::RandomState;
+    let mut hasher = <RandomState as BuildHasher>::Hasher::new();
     x.hash(&mut hasher);
     hasher.finish()
 }

--- a/rational/src/lib.rs
+++ b/rational/src/lib.rs
@@ -670,8 +670,9 @@ impl RatioErrorKind {
 
 #[cfg(test)]
 fn hash<T: hash::Hash>(x: &T) -> u64 {
-    use std::hash::Hasher;
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    use std::hash::{BuildHasher, Hasher};
+    use std::collections::hash_map::RandomState;
+    let mut hasher = <RandomState as BuildHasher>::Hasher::new();
     x.hash(&mut hasher);
     hasher.finish()
 }

--- a/rational/src/lib.rs
+++ b/rational/src/lib.rs
@@ -671,7 +671,7 @@ impl RatioErrorKind {
 #[cfg(test)]
 fn hash<T: hash::Hash>(x: &T) -> u64 {
     use std::hash::Hasher;
-    let mut hasher = hash::SipHasher::new();
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
     x.hash(&mut hasher);
     hasher.finish()
 }


### PR DESCRIPTION
`DefaultHasher` wasn't stable until 1.13, at which point all the other
hashers were deprecated, so it's not easy for us to name a hasher type to
use for testing.  However, `RandomState` has been stable since 1.7, and it
implements `BuildHasher` that has a `Hasher` associated type.

(extends #287)