### PR TITLE
Implement associated trait const for ZERO / ONE where possible, behind default-off feature gate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,8 @@ complex = ["num-complex"]
 rational = ["num-rational"]
 default = ["bigint", "complex", "rational", "rustc-serialize"]
 
+experimental_trait_consts = []
+
 serde = [
   "num-bigint/serde",
   "num-complex/serde",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,8 @@ pub use num_rational::BigRational;
 pub use num_complex::Complex;
 pub use num_integer::Integer;
 pub use num_iter::{range, range_inclusive, range_step, range_step_inclusive};
+#[cfg(feature="experimental_trait_consts")]
+pub use num_traits::{ZeroConst, OneConst};
 pub use num_traits::{Num, Zero, One, Signed, Unsigned, Bounded,
                      one, zero, abs, abs_sub, signum,
                      Saturating, CheckedAdd, CheckedSub, CheckedMul, CheckedDiv,

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -10,3 +10,6 @@ name = "num-traits"
 version = "0.1.37"
 
 [dependencies]
+
+[features]
+"experimental_trait_consts" = []

--- a/traits/src/identities.rs
+++ b/traits/src/identities.rs
@@ -25,6 +25,11 @@ pub trait Zero: Sized + Add<Self, Output = Self> {
     fn is_zero(&self) -> bool;
 }
 
+#[cfg(feature="experimental_trait_consts")]
+pub trait ZeroConst: Zero {
+    const ZERO: Self;
+}
+
 macro_rules! zero_impl {
     ($t:ty, $v:expr) => {
         impl Zero for $t {
@@ -79,6 +84,11 @@ pub trait One: Sized + Mul<Self, Output = Self> {
     /// `static mut`s.
     // FIXME (#5527): This should be an associated constant
     fn one() -> Self;
+}
+
+#[cfg(feature="experimental_trait_consts")]
+pub trait OneConst: One {
+    const ONE: Self;
 }
 
 macro_rules! one_impl {

--- a/traits/src/identities.rs
+++ b/traits/src/identities.rs
@@ -38,6 +38,10 @@ macro_rules! zero_impl {
             #[inline]
             fn is_zero(&self) -> bool { *self == $v }
         }
+        #[cfg(feature="experimental_trait_consts")]
+        impl ZeroConst for $t {
+            const ZERO: Self = $v;
+        }
     }
 }
 
@@ -96,6 +100,10 @@ macro_rules! one_impl {
         impl One for $t {
             #[inline]
             fn one() -> $t { $v }
+        }
+        #[cfg(feature="experimental_trait_consts")]
+        impl OneConst for $t {
+            const ONE: Self = $v;
         }
     }
 }

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -23,6 +23,8 @@ use std::num::Wrapping;
 pub use bounds::Bounded;
 pub use float::{Float, FloatConst};
 pub use identities::{Zero, One, zero, one};
+#[cfg(feature="experimental_trait_consts")]
+pub use identities::{ZeroConst, OneConst};
 pub use ops::checked::*;
 pub use ops::wrapping::*;
 pub use ops::saturating::Saturating;

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -14,6 +14,8 @@
        html_root_url = "https://rust-num.github.io/num/",
        html_playground_url = "http://play.integer32.com/")]
 
+#![cfg_attr(feature="experimental_trait_consts", feature(associated_consts))]
+
 use std::ops::{Add, Sub, Mul, Div, Rem};
 use std::ops::{AddAssign, SubAssign, MulAssign, DivAssign, RemAssign};
 use std::num::Wrapping;


### PR DESCRIPTION
For me, the biggest missing feature in num is the ability to use Zero() / One() without incurring overhead. The inline hints probably cause many uses to optimize away, but this isn't true in Debug builds, at least.

Without better support from the compiler (for consts with destructors, specifically), it will not be possible to add a blanket impl for the const version. For that reason, I have made 2 new traits, ZeroConst and OneConst, which are feature-gated, and off by default.

For performance-critical applications, these can be added as trait bounds, and will provide ::ZERO and ::ONE as Self-type consts. Here's a snippet from an actual program, using these new traits:

```rust
use num::{Integer, ZeroConst, OneConst};

// ....

impl<T> Repr<T> for bool where
    T: Integer + ZeroConst + OneConst
{
    fn decode(x: T) -> Self { x > T::ZERO }
    fn encode(self) -> T { if self { T::ONE } else { T::ZERO } }
}
```

This probably should never escape the feature gate, but it provides a very valuable way for users needing the const version to get it, without resorting to worse hackery. I look forward to hearing your feedback.