### PR TITLE
traits: Introduce std feature

### DIFF
--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -10,6 +10,10 @@ for package in bigint complex integer iter rational traits; do
   cargo test --manifest-path $package/Cargo.toml
 done
 
+# Only num-tratis supports no_std at the moment.
+cargo build --manifest-path traits/Cargo.toml --no-default-features
+cargo test --manifest-path traits/Cargo.toml --no-default-features
+
 # Each isolated feature should also work everywhere.
 for feature in '' bigint rational complex; do
   cargo build --verbose --no-default-features --features="$feature"

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -10,7 +10,7 @@ for package in bigint complex integer iter rational traits; do
   cargo test --manifest-path $package/Cargo.toml
 done
 
-# Only num-tratis supports no_std at the moment.
+# Only num-traits supports no_std at the moment.
 cargo build --manifest-path traits/Cargo.toml --no-default-features
 cargo test --manifest-path traits/Cargo.toml --no-default-features
 

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -10,3 +10,7 @@ name = "num-traits"
 version = "0.1.37"
 
 [dependencies]
+
+[features]
+default = ["std"]
+std = []

--- a/traits/src/bounds.rs
+++ b/traits/src/bounds.rs
@@ -1,7 +1,7 @@
-use std::{usize, u8, u16, u32, u64};
-use std::{isize, i8, i16, i32, i64};
-use std::{f32, f64};
-use std::num::Wrapping;
+use core::{usize, u8, u16, u32, u64};
+use core::{isize, i8, i16, i32, i64};
+use core::{f32, f64};
+use core::num::Wrapping;
 
 /// Numbers which have upper and lower bounds
 pub trait Bounded {

--- a/traits/src/cast.rs
+++ b/traits/src/cast.rs
@@ -3,7 +3,7 @@ use core::num::Wrapping;
 
 use identities::Zero;
 use bounds::Bounded;
-use float::BasicFloat;
+use float::Float;
 
 /// A generic trait for converting a value to a number.
 pub trait ToPrimitive {
@@ -228,7 +228,7 @@ macro_rules! impl_to_primitive_float_to_float {
             // NaN and +-inf are cast as they are.
             let n = $slf as f64;
             let max_value: $DstT = ::core::$DstT::MAX;
-            if !BasicFloat::is_finite(n) || (-max_value as f64 <= n && n <= max_value as f64) {
+            if !Float::is_finite(n) || (-max_value as f64 <= n && n <= max_value as f64) {
                 Some($slf as $DstT)
             } else {
                 None

--- a/traits/src/cast.rs
+++ b/traits/src/cast.rs
@@ -1,8 +1,9 @@
-use std::mem::size_of;
-use std::num::Wrapping;
+use core::mem::size_of;
+use core::num::Wrapping;
 
 use identities::Zero;
 use bounds::Bounded;
+use float::BasicFloat;
 
 /// A generic trait for converting a value to a number.
 pub trait ToPrimitive {
@@ -226,8 +227,8 @@ macro_rules! impl_to_primitive_float_to_float {
             // Make sure the value is in range for the cast.
             // NaN and +-inf are cast as they are.
             let n = $slf as f64;
-            let max_value: $DstT = ::std::$DstT::MAX;
-            if !n.is_finite() || (-max_value as f64 <= n && n <= max_value as f64) {
+            let max_value: $DstT = ::core::$DstT::MAX;
+            if !BasicFloat::is_finite(n) || (-max_value as f64 <= n && n <= max_value as f64) {
                 Some($slf as $DstT)
             } else {
                 None
@@ -454,8 +455,8 @@ impl<T: NumCast> NumCast for Wrapping<T> {
 
 #[test]
 fn to_primitive_float() {
-    use std::f32;
-    use std::f64;
+    use core::f32;
+    use core::f64;
 
     let f32_toolarge = 1e39f64;
     assert_eq!(f32_toolarge.to_f32(), None);

--- a/traits/src/float.rs
+++ b/traits/src/float.rs
@@ -10,7 +10,11 @@ use {ToPrimitive, Num, NumCast};
 // FIXME: these doctests aren't actually helpful, because they're using and
 // testing the inherent methods directly, not going through `Float`.
 
-/// Floating point operations that work with `std`.
+/// Floating point operations.
+///
+/// Please note that some methods are disabled for `no_std`. If you implement it
+/// only for `no_std`, the build will fail if anyone else in the dependency
+/// graph enables `num-traits/std`.
 pub trait Float
     : Num
     + Copy

--- a/traits/src/float.rs
+++ b/traits/src/float.rs
@@ -1285,16 +1285,12 @@ macro_rules! float_impl {
 
             #[inline]
             fn to_degrees(self) -> Self {
-                // NB: `f32` didn't stabilize this until 1.7
-                // <$T>::to_degrees(self)
-                self * (180. / ::core::$T::consts::PI)
+                <$T>::to_degrees(self)
             }
 
             #[inline]
             fn to_radians(self) -> Self {
-                // NB: `f32` didn't stabilize this until 1.7
-                // <$T>::to_radians(self)
-                self * (::core::$T::consts::PI / 180.)
+                <$T>::to_radians(self)
             }
 
             #[cfg(feature = "std")]

--- a/traits/src/float.rs
+++ b/traits/src/float.rs
@@ -682,6 +682,8 @@ pub trait Float
 
     /// Returns the maximum of the two numbers.
     ///
+    /// If one of the arguments is NaN, then the other argument is returned.
+    ///
     /// ```
     /// use num_traits::Float;
     ///
@@ -690,10 +692,20 @@ pub trait Float
     ///
     /// assert_eq!(x.max(y), y);
     /// ```
-    #[cfg(feature = "std")]
-    fn max(self, other: Self) -> Self;
+    #[inline]
+    fn max(self, other: Self) -> Self {
+        if self.is_nan() {
+            return other;
+        }
+        if other.is_nan() {
+            return self;
+        }
+        if self > other { self } else { other }
+    }
 
     /// Returns the minimum of the two numbers.
+    ///
+    /// If one of the arguments is NaN, then the other argument is returned.
     ///
     /// ```
     /// use num_traits::Float;
@@ -703,8 +715,16 @@ pub trait Float
     ///
     /// assert_eq!(x.min(y), x);
     /// ```
-    #[cfg(feature = "std")]
-    fn min(self, other: Self) -> Self;
+    #[inline]
+    fn min(self, other: Self) -> Self {
+        if self.is_nan() {
+            return other;
+        }
+        if other.is_nan() {
+            return self;
+        }
+        if self < other { self } else { other }
+    }
 
     /// The positive difference of two numbers.
     ///

--- a/traits/src/float.rs
+++ b/traits/src/float.rs
@@ -1268,14 +1268,28 @@ macro_rules! float_impl {
                 <$T>::log10(self)
             }
 
+            #[cfg(feature = "std")]
             #[inline]
             fn to_degrees(self) -> Self {
                 <$T>::to_degrees(self)
             }
 
+            #[cfg(feature = "std")]
             #[inline]
             fn to_radians(self) -> Self {
                 <$T>::to_radians(self)
+            }
+
+            #[cfg(not(feature = "std"))]
+            #[inline]
+            fn to_degrees(self) -> Self {
+               self * (180. / ::core::$T::consts::PI)
+            }
+
+            #[cfg(not(feature = "std"))]
+            #[inline]
+            fn to_radians(self) -> Self {
+               self * (::core::$T::consts::PI / 180.)
             }
 
             #[cfg(feature = "std")]

--- a/traits/src/float.rs
+++ b/traits/src/float.rs
@@ -5,7 +5,7 @@ use core::num::FpCategory;
 // Used for default implementation of `epsilon`
 use core::f32;
 
-use {Num, NumCast};
+use {ToPrimitive, Num, NumCast};
 
 // FIXME: these doctests aren't actually helpful, because they're using and
 // testing the inherent methods directly, not going through `Float`.
@@ -456,32 +456,13 @@ pub trait Float
     /// assert!(abs_difference < 1e-10);
     /// ```
     #[inline]
-    fn powi(self, mut exp: i32) -> Self {
-        if exp == 0 { return Self::one() }
-
-        let mut base;
+    fn powi(mut self, mut exp: i32) -> Self {
         if exp < 0 {
+            self = self.recip();
             exp = -exp;
-            base = self.recip();
-        } else {
-            base = self;
         }
-
-        while exp & 1 == 0 {
-            base = base * base;
-            exp >>= 1;
-        }
-        if exp == 1 { return base }
-
-        let mut acc = base;
-        while exp > 1 {
-            exp >>= 1;
-            base = base * base;
-            if exp & 1 == 1 {
-                acc = acc * base;
-            }
-        }
-        acc
+        // It should always be possible to convert a positive `i32` to a `usize`.
+        super::pow(self, exp.to_usize().unwrap())
     }
 
     /// Raise a number to a floating point power.

--- a/traits/src/identities.rs
+++ b/traits/src/identities.rs
@@ -1,5 +1,5 @@
-use std::ops::{Add, Mul};
-use std::num::Wrapping;
+use core::ops::{Add, Mul};
+use core::num::Wrapping;
 
 /// Defines an additive identity element for `Self`.
 pub trait Zero: Sized + Add<Self, Output = Self> {

--- a/traits/src/int.rs
+++ b/traits/src/int.rs
@@ -1,4 +1,4 @@
-use std::ops::{Not, BitAnd, BitOr, BitXor, Shl, Shr};
+use core::ops::{Not, BitAnd, BitOr, BitXor, Shl, Shr};
 
 use {Num, NumCast};
 use bounds::Bounded;

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -23,7 +23,7 @@ use core::ops::{AddAssign, SubAssign, MulAssign, DivAssign, RemAssign};
 use core::num::Wrapping;
 
 pub use bounds::Bounded;
-pub use float::{BasicFloat, Float, FloatConst};
+pub use float::{Float, FloatConst};
 pub use identities::{Zero, One, zero, one};
 pub use ops::checked::*;
 pub use ops::wrapping::*;
@@ -185,9 +185,9 @@ macro_rules! float_trait_impl {
 
                 // Special values
                 match src {
-                    "inf"   => return Ok(BasicFloat::infinity()),
-                    "-inf"  => return Ok(BasicFloat::neg_infinity()),
-                    "NaN"   => return Ok(BasicFloat::nan()),
+                    "inf"   => return Ok(Float::infinity()),
+                    "-inf"  => return Ok(Float::neg_infinity()),
+                    "NaN"   => return Ok(Float::nan()),
                     _       => {},
                 }
 
@@ -228,15 +228,15 @@ macro_rules! float_trait_impl {
                             // if we've not seen any non-zero digits.
                             if prev_sig != 0.0 {
                                 if is_positive && sig <= prev_sig
-                                    { return Ok(BasicFloat::infinity()); }
+                                    { return Ok(Float::infinity()); }
                                 if !is_positive && sig >= prev_sig
-                                    { return Ok(BasicFloat::neg_infinity()); }
+                                    { return Ok(Float::neg_infinity()); }
 
                                 // Detect overflow by reversing the shift-and-add process
                                 if is_positive && (prev_sig != (sig - digit as $t) / radix as $t)
-                                    { return Ok(BasicFloat::infinity()); }
+                                    { return Ok(Float::infinity()); }
                                 if !is_positive && (prev_sig != (sig + digit as $t) / radix as $t)
-                                    { return Ok(BasicFloat::neg_infinity()); }
+                                    { return Ok(Float::neg_infinity()); }
                             }
                             prev_sig = sig;
                         },
@@ -272,9 +272,9 @@ macro_rules! float_trait_impl {
                                 };
                                 // Detect overflow by comparing to last value
                                 if is_positive && sig < prev_sig
-                                    { return Ok(BasicFloat::infinity()); }
+                                    { return Ok(Float::infinity()); }
                                 if !is_positive && sig > prev_sig
-                                    { return Ok(BasicFloat::neg_infinity()); }
+                                    { return Ok(Float::neg_infinity()); }
                                 prev_sig = sig;
                             },
                             None => match c {
@@ -309,8 +309,8 @@ macro_rules! float_trait_impl {
                         };
 
                         match (is_positive, exp) {
-                            (true,  Ok(exp)) => BasicFloat::powi(base, exp as i32),
-                            (false, Ok(exp)) => 1.0 / BasicFloat::powi(base, exp as i32),
+                            (true,  Ok(exp)) => Float::powi(base, exp as i32),
+                            (false, Ok(exp)) => 1.0 / Float::powi(base, exp as i32),
                             (_, Err(_))      => return Err(PFE { kind: Invalid }),
                         }
                     },

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -14,6 +14,8 @@
        html_root_url = "https://rust-num.github.io/num/",
        html_playground_url = "http://play.integer32.com/")]
 
+#![deny(unconditional_recursion)]
+
 #![cfg_attr(not(feature = "std"), no_std)]
 #[cfg(feature = "std")]
 extern crate core;

--- a/traits/src/ops/checked.rs
+++ b/traits/src/ops/checked.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Sub, Mul, Div};
+use core::ops::{Add, Sub, Mul, Div};
 
 /// Performs addition that returns `None` instead of wrapping around on
 /// overflow.

--- a/traits/src/ops/wrapping.rs
+++ b/traits/src/ops/wrapping.rs
@@ -1,5 +1,5 @@
-use std::ops::{Add, Sub, Mul};
-use std::num::Wrapping;
+use core::ops::{Add, Sub, Mul};
+use core::num::Wrapping;
 
 macro_rules! wrapping_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {

--- a/traits/src/pow.rs
+++ b/traits/src/pow.rs
@@ -1,4 +1,4 @@
-use std::ops::Mul;
+use core::ops::Mul;
 use {One, CheckedMul};
 
 /// Raises a value to the power of exp, using exponentiation by squaring.

--- a/traits/src/sign.rs
+++ b/traits/src/sign.rs
@@ -1,6 +1,6 @@
-use std::ops::Neg;
-use std::{f32, f64};
-use std::num::Wrapping;
+use core::ops::Neg;
+use core::{f32, f64};
+use core::num::Wrapping;
 
 use Num;
 
@@ -104,16 +104,15 @@ macro_rules! signed_float_impl {
             /// Computes the absolute value. Returns `NAN` if the number is `NAN`.
             #[inline]
             fn abs(&self) -> $t {
-                <$t>::abs(*self)
+                (*self).abs()
             }
 
             /// The positive difference of two numbers. Returns `0.0` if the number is
             /// less than or equal to `other`, otherwise the difference between`self`
             /// and `other` is returned.
             #[inline]
-            #[allow(deprecated)]
             fn abs_sub(&self, other: &$t) -> $t {
-                <$t>::abs_sub(*self, *other)
+                if *self <= *other { 0. } else { *self - *other }
             }
 
             /// # Returns
@@ -123,7 +122,7 @@ macro_rules! signed_float_impl {
             /// - `NAN` if the number is NaN
             #[inline]
             fn signum(&self) -> $t {
-                <$t>::signum(*self)
+                (*self).signum()
             }
 
             /// Returns `true` if the number is positive, including `+0.0` and `INFINITY`

--- a/traits/src/sign.rs
+++ b/traits/src/sign.rs
@@ -2,7 +2,7 @@ use core::ops::Neg;
 use core::{f32, f64};
 use core::num::Wrapping;
 
-use Num;
+use {Num, Float};
 
 /// Useful functions for signed numbers (i.e. numbers that can be negative).
 pub trait Signed: Sized + Num + Neg<Output = Self> {
@@ -122,7 +122,7 @@ macro_rules! signed_float_impl {
             /// - `NAN` if the number is NaN
             #[inline]
             fn signum(&self) -> $t {
-                (*self).signum()
+                Float::signum(*self)
             }
 
             /// Returns `true` if the number is positive, including `+0.0` and `INFINITY`


### PR DESCRIPTION
This makes it possible to build `traits` without `std`. For this a new
trait `BasicFloat` was introduced, implementing some basic functionality
that works with `core`. Most notably this is lacking functions like
`cos`, `sin`, etc.

`Float` is not available without `std`.

Refs #216.