### PR TITLE
Test and fix subcrates with --no-default-features

### DIFF
--- a/bigint/Cargo.toml
+++ b/bigint/Cargo.toml
@@ -31,5 +31,8 @@ version = "0.3.19"
 optional = true
 version = ">= 0.7.0, < 0.9.0"
 
+[dev-dependencies.rand]
+version = "0.3.14"
+
 [features]
 default = ["rand", "rustc-serialize"]

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -10,9 +10,11 @@ for package in bigint complex integer iter rational traits; do
   cargo test --manifest-path $package/Cargo.toml
 done
 
-# Only num-traits supports no_std at the moment.
-cargo build --manifest-path traits/Cargo.toml --no-default-features
-cargo test --manifest-path traits/Cargo.toml --no-default-features
+# They all should build with minimal features too
+for package in bigint complex integer iter rational traits; do
+  cargo build --manifest-path $package/Cargo.toml --no-default-features
+  cargo test --manifest-path $package/Cargo.toml --no-default-features
+done
 
 # Each isolated feature should also work everywhere.
 for feature in '' bigint rational complex; do

--- a/rational/src/lib.rs
+++ b/rational/src/lib.rs
@@ -668,6 +668,7 @@ impl RatioErrorKind {
     }
 }
 
+#[cfg(feature = "num-bigint")]
 impl FromPrimitive for Ratio<BigInt> {
     fn from_i64(n: i64) -> Option<Self> {
         Some(Ratio::from_integer(n.into()))
@@ -859,7 +860,7 @@ mod test {
     use std::str::FromStr;
     use std::i32;
     use std::f64;
-    use traits::{Zero, One, Signed, FromPrimitive, Float};
+    use traits::{Zero, One, Signed, FromPrimitive};
 
     pub const _0: Rational = Ratio {
         numer: 0,
@@ -1301,6 +1302,7 @@ mod test {
     #[cfg(feature = "num-bigint")]
     #[test]
     fn test_from_float() {
+        use traits::Float;
         fn test<T: Float>(given: T, (numer, denom): (&str, &str)) {
             let ratio: BigRational = Ratio::from_float(given).unwrap();
             assert_eq!(ratio,


### PR DESCRIPTION
- The CI script now tests them all with --no-default-features.
- bigint: testing needs rand even when the main feature is disabled.
- rational: gate `FromPrimitive for Ratio<BigInt>` on having bigint.