### PR TITLE
Revert "Auto merge of #296 - vks:no_std, r=cuviper"

### DIFF
--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -10,7 +10,3 @@ name = "num-traits"
 version = "0.1.38"
 
 [dependencies]
-
-[features]
-default = ["std"]
-std = []

--- a/traits/src/bounds.rs
+++ b/traits/src/bounds.rs
@@ -1,7 +1,7 @@
-use core::{usize, u8, u16, u32, u64};
-use core::{isize, i8, i16, i32, i64};
-use core::{f32, f64};
-use core::num::Wrapping;
+use std::{usize, u8, u16, u32, u64};
+use std::{isize, i8, i16, i32, i64};
+use std::{f32, f64};
+use std::num::Wrapping;
 
 /// Numbers which have upper and lower bounds
 pub trait Bounded {

--- a/traits/src/cast.rs
+++ b/traits/src/cast.rs
@@ -1,9 +1,8 @@
-use core::mem::size_of;
-use core::num::Wrapping;
+use std::mem::size_of;
+use std::num::Wrapping;
 
 use identities::Zero;
 use bounds::Bounded;
-use float::Float;
 
 /// A generic trait for converting a value to a number.
 pub trait ToPrimitive {
@@ -227,8 +226,8 @@ macro_rules! impl_to_primitive_float_to_float {
             // Make sure the value is in range for the cast.
             // NaN and +-inf are cast as they are.
             let n = $slf as f64;
-            let max_value: $DstT = ::core::$DstT::MAX;
-            if !Float::is_finite(n) || (-max_value as f64 <= n && n <= max_value as f64) {
+            let max_value: $DstT = ::std::$DstT::MAX;
+            if !n.is_finite() || (-max_value as f64 <= n && n <= max_value as f64) {
                 Some($slf as $DstT)
             } else {
                 None
@@ -455,8 +454,8 @@ impl<T: NumCast> NumCast for Wrapping<T> {
 
 #[test]
 fn to_primitive_float() {
-    use core::f32;
-    use core::f64;
+    use std::f32;
+    use std::f64;
 
     let f32_toolarge = 1e39f64;
     assert_eq!(f32_toolarge.to_f32(), None);

--- a/traits/src/identities.rs
+++ b/traits/src/identities.rs
@@ -1,5 +1,5 @@
-use core::ops::{Add, Mul};
-use core::num::Wrapping;
+use std::ops::{Add, Mul};
+use std::num::Wrapping;
 
 /// Defines an additive identity element for `Self`.
 pub trait Zero: Sized + Add<Self, Output = Self> {

--- a/traits/src/int.rs
+++ b/traits/src/int.rs
@@ -1,4 +1,4 @@
-use core::ops::{Not, BitAnd, BitOr, BitXor, Shl, Shr};
+use std::ops::{Not, BitAnd, BitOr, BitXor, Shl, Shr};
 
 use {Num, NumCast};
 use bounds::Bounded;

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -14,15 +14,9 @@
        html_root_url = "https://rust-num.github.io/num/",
        html_playground_url = "http://play.integer32.com/")]
 
-#![deny(unconditional_recursion)]
-
-#![cfg_attr(not(feature = "std"), no_std)]
-#[cfg(feature = "std")]
-extern crate core;
-
-use core::ops::{Add, Sub, Mul, Div, Rem};
-use core::ops::{AddAssign, SubAssign, MulAssign, DivAssign, RemAssign};
-use core::num::Wrapping;
+use std::ops::{Add, Sub, Mul, Div, Rem};
+use std::ops::{AddAssign, SubAssign, MulAssign, DivAssign, RemAssign};
+use std::num::Wrapping;
 
 pub use bounds::Bounded;
 pub use float::{Float, FloatConst};
@@ -135,10 +129,10 @@ impl<T> NumAssignRef for T where T: NumAssign + for<'r> NumAssignOps<&'r T> {}
 macro_rules! int_trait_impl {
     ($name:ident for $($t:ty)*) => ($(
         impl $name for $t {
-            type FromStrRadixErr = ::core::num::ParseIntError;
+            type FromStrRadixErr = ::std::num::ParseIntError;
             #[inline]
             fn from_str_radix(s: &str, radix: u32)
-                              -> Result<Self, ::core::num::ParseIntError>
+                              -> Result<Self, ::std::num::ParseIntError>
             {
                 <$t>::from_str_radix(s, radix)
             }
@@ -164,7 +158,7 @@ pub enum FloatErrorKind {
     Empty,
     Invalid,
 }
-// FIXME: core::num::ParseFloatError is stable in 1.0, but opaque to us,
+// FIXME: std::num::ParseFloatError is stable in 1.0, but opaque to us,
 // so there's not really any way for us to reuse it.
 #[derive(Debug)]
 pub struct ParseFloatError {
@@ -311,8 +305,8 @@ macro_rules! float_trait_impl {
                         };
 
                         match (is_positive, exp) {
-                            (true,  Ok(exp)) => Float::powi(base, exp as i32),
-                            (false, Ok(exp)) => 1.0 / Float::powi(base, exp as i32),
+                            (true,  Ok(exp)) => base.powi(exp as i32),
+                            (false, Ok(exp)) => 1.0 / base.powi(exp as i32),
                             (_, Err(_))      => return Err(PFE { kind: Invalid }),
                         }
                     },

--- a/traits/src/ops/checked.rs
+++ b/traits/src/ops/checked.rs
@@ -1,4 +1,4 @@
-use core::ops::{Add, Sub, Mul, Div};
+use std::ops::{Add, Sub, Mul, Div};
 
 /// Performs addition that returns `None` instead of wrapping around on
 /// overflow.

--- a/traits/src/ops/wrapping.rs
+++ b/traits/src/ops/wrapping.rs
@@ -1,5 +1,5 @@
-use core::ops::{Add, Sub, Mul};
-use core::num::Wrapping;
+use std::ops::{Add, Sub, Mul};
+use std::num::Wrapping;
 
 macro_rules! wrapping_impl {
     ($trait_name:ident, $method:ident, $t:ty) => {

--- a/traits/src/pow.rs
+++ b/traits/src/pow.rs
@@ -1,4 +1,4 @@
-use core::ops::Mul;
+use std::ops::Mul;
 use {One, CheckedMul};
 
 /// Raises a value to the power of exp, using exponentiation by squaring.

--- a/traits/src/sign.rs
+++ b/traits/src/sign.rs
@@ -1,8 +1,8 @@
-use core::ops::Neg;
-use core::{f32, f64};
-use core::num::Wrapping;
+use std::ops::Neg;
+use std::{f32, f64};
+use std::num::Wrapping;
 
-use {Num, Float};
+use Num;
 
 /// Useful functions for signed numbers (i.e. numbers that can be negative).
 pub trait Signed: Sized + Num + Neg<Output = Self> {
@@ -104,15 +104,16 @@ macro_rules! signed_float_impl {
             /// Computes the absolute value. Returns `NAN` if the number is `NAN`.
             #[inline]
             fn abs(&self) -> $t {
-                (*self).abs()
+                <$t>::abs(*self)
             }
 
             /// The positive difference of two numbers. Returns `0.0` if the number is
             /// less than or equal to `other`, otherwise the difference between`self`
             /// and `other` is returned.
             #[inline]
+            #[allow(deprecated)]
             fn abs_sub(&self, other: &$t) -> $t {
-                if *self <= *other { 0. } else { *self - *other }
+                <$t>::abs_sub(*self, *other)
             }
 
             /// # Returns
@@ -122,7 +123,7 @@ macro_rules! signed_float_impl {
             /// - `NAN` if the number is NaN
             #[inline]
             fn signum(&self) -> $t {
-                Float::signum(*self)
+                <$t>::signum(*self)
             }
 
             /// Returns `true` if the number is positive, including `+0.0` and `INFINITY`


### PR DESCRIPTION
This reverts commit 8b5d4ac24e6d1417359f684ccfde506838a7d2cc, reversing
changes made to ef752e46877dc163ec28ddcf4d71558c264bb78d.

See #297 -- it's a breaking change to feature-gate existing APIs.