### PR TITLE
Add BigInt two's complement conversions

### DIFF
--- a/bigint/src/bigint.rs
+++ b/bigint/src/bigint.rs
@@ -1,5 +1,5 @@
 use std::default::Default;
-use std::ops::{Add, Div, Mul, Neg, Rem, Shl, Shr, Sub, Not, DerefMut};
+use std::ops::{Add, Div, Mul, Neg, Rem, Shl, Shr, Sub, Not};
 use std::str::{self, FromStr};
 use std::fmt;
 use std::cmp::Ordering::{self, Less, Greater, Equal};
@@ -16,7 +16,7 @@ use serde;
 use rand::Rng;
 
 use integer::Integer;
-use traits::{ToPrimitive, FromPrimitive, Num, WrappingAdd, CheckedAdd, CheckedSub,
+use traits::{ToPrimitive, FromPrimitive, Num, CheckedAdd, CheckedSub,
              CheckedMul, CheckedDiv, Signed, Zero, One};
 
 use self::Sign::{Minus, NoSign, Plus};
@@ -1214,16 +1214,14 @@ fn twos_complement_be(digits: &mut [u8]) {
 /// Perform in-place two's complement of the given digit iterator
 /// starting from the least significant byte.
 #[inline]
-fn twos_complement<T, R, I>(digits: I)
-    where I: IntoIterator<Item = R>,
-          R: DerefMut<Target = T>,
-          T: Clone + Not<Output = T> + WrappingAdd + Zero + One
+fn twos_complement<'a, I>(digits: I)
+    where I: IntoIterator<Item = &'a mut u8>
 {
     let mut carry = true;
     for mut d in digits {
-        *d = d.clone().not();
+        *d = d.not();
         if carry {
-            *d = d.wrapping_add(&T::one());
+            *d = d.wrapping_add(1);
             carry = d.is_zero();
         }
     }

--- a/bigint/src/tests/bigint.rs
+++ b/bigint/src/tests/bigint.rs
@@ -107,41 +107,74 @@ fn test_to_bytes_le() {
 }
 
 #[test]
-fn test_from_twos_complement_bytes_le() {
-    fn check(s: Vec<u8>, result: &str) {
-        assert_eq!(BigInt::from_twos_complement_bytes_le(s),
-                   BigInt::parse_bytes(result.as_bytes(), 10).unwrap());
+fn test_to_signed_bytes_le() {
+    fn check(s: &str, result: Vec<u8>) {
+        assert_eq!(BigInt::parse_bytes(s.as_bytes(), 10).unwrap().to_signed_bytes_le(),
+                   result);
     }
 
-    check(vec![], "0");
-    check(vec![0], "0");
-    check(vec![0; 10], "0");
-    check(vec![255, 127], "32767");
-    check(vec![255], "-1");
-    check(vec![0, 0, 0, 1], "16777216");
-    check(vec![156], "-100");
-    check(vec![0, 0, 128], "-8388608");
-    check(vec![255; 10], "-1");
+    check("0", vec![0]);
+    check("32767", vec![0xff, 0x7f]);
+    check("-1", vec![0xff]);
+    check("16777216", vec![0, 0, 0, 1]);
+    check("-100", vec![156]);
+    check("-8388608", vec![0, 0, 0x80]);
+    check("-192", vec![0x40, 0xff]);
 }
 
 #[test]
-fn test_from_twos_complement_bytes_be() {
-    fn check(s: Vec<u8>, result: &str) {
-        assert_eq!(BigInt::from_twos_complement_bytes_be(s),
+fn test_from_signed_bytes_le() {
+    fn check(s: &[u8], result: &str) {
+        assert_eq!(BigInt::from_signed_bytes_le(s),
                    BigInt::parse_bytes(result.as_bytes(), 10).unwrap());
     }
 
-    check(vec![], "0");
-    check(vec![0], "0");
-    check(vec![0; 10], "0");
-    check(vec![127, 255], "32767");
-    check(vec![255], "-1");
-    check(vec![1, 0, 0, 0], "16777216");
-    check(vec![156], "-100");
-    check(vec![128, 0, 0], "-8388608");
-    check(vec![255; 10], "-1");
+    check(&[], "0");
+    check(&[0], "0");
+    check(&[0; 10], "0");
+    check(&[0xff, 0x7f], "32767");
+    check(&[0xff], "-1");
+    check(&[0, 0, 0, 1], "16777216");
+    check(&[156], "-100");
+    check(&[0, 0, 0x80], "-8388608");
+    check(&[0xff; 10], "-1");
+    check(&[0x40, 0xff], "-192");
 }
 
+#[test]
+fn test_to_signed_bytes_be() {
+    fn check(s: &str, result: Vec<u8>) {
+        assert_eq!(BigInt::parse_bytes(s.as_bytes(), 10).unwrap().to_signed_bytes_be(),
+                   result);
+    }
+
+    check("0", vec![0]);
+    check("32767", vec![0x7f, 0xff]);
+    check("-1", vec![255]);
+    check("16777216", vec![1, 0, 0, 0]);
+    check("-100", vec![156]);
+    check("-8388608", vec![128, 0, 0]);
+    check("-192", vec![0xff, 0x40]);
+}
+
+#[test]
+fn test_from_signed_bytes_be() {
+    fn check(s: &[u8], result: &str) {
+        assert_eq!(BigInt::from_signed_bytes_be(s),
+                   BigInt::parse_bytes(result.as_bytes(), 10).unwrap());
+    }
+
+    check(&[], "0");
+    check(&[0], "0");
+    check(&[0; 10], "0");
+    check(&[127, 255], "32767");
+    check(&[255], "-1");
+    check(&[1, 0, 0, 0], "16777216");
+    check(&[156], "-100");
+    check(&[128, 0, 0], "-8388608");
+    check(&[255; 10], "-1");
+    check(&[0xff, 0x40], "-192");
+}
 
 #[test]
 fn test_cmp() {

--- a/bigint/src/tests/bigint.rs
+++ b/bigint/src/tests/bigint.rs
@@ -107,6 +107,43 @@ fn test_to_bytes_le() {
 }
 
 #[test]
+fn test_from_twos_complement_bytes_le() {
+    fn check(s: Vec<u8>, result: &str) {
+        assert_eq!(BigInt::from_twos_complement_bytes_le(s),
+                   BigInt::parse_bytes(result.as_bytes(), 10).unwrap());
+    }
+
+    check(vec![], "0");
+    check(vec![0], "0");
+    check(vec![0; 10], "0");
+    check(vec![255, 127], "32767");
+    check(vec![255], "-1");
+    check(vec![0, 0, 0, 1], "16777216");
+    check(vec![156], "-100");
+    check(vec![0, 0, 128], "-8388608");
+    check(vec![255; 10], "-1");
+}
+
+#[test]
+fn test_from_twos_complement_bytes_be() {
+    fn check(s: Vec<u8>, result: &str) {
+        assert_eq!(BigInt::from_twos_complement_bytes_be(s),
+                   BigInt::parse_bytes(result.as_bytes(), 10).unwrap());
+    }
+
+    check(vec![], "0");
+    check(vec![0], "0");
+    check(vec![0; 10], "0");
+    check(vec![127, 255], "32767");
+    check(vec![255], "-1");
+    check(vec![1, 0, 0, 0], "16777216");
+    check(vec![156], "-100");
+    check(vec![128, 0, 0], "-8388608");
+    check(vec![255; 10], "-1");
+}
+
+
+#[test]
 fn test_cmp() {
     let vs: [&[BigDigit]; 4] = [&[2 as BigDigit], &[1, 1], &[2, 1], &[1, 1, 1]];
     let mut nums = Vec::new();


### PR DESCRIPTION
This PR provides the methods `from_signed_bytes_le`, `from_signed_bytes_be`, `to_signed_bytes_le`, and `to_signed_bytes_be` to `BigInt`. This concern came around with [this SO question](https://stackoverflow.com/q/44345786/1233251), in which we realized that there was no readily available conversion from arrays in two's complement binary representation to a `BigInt`.
Please let me know what further changes should be made before it's good to go. In particular:

- Should the helper functions `twos_complement_(le|be)` go elsewhere? The algorithms module seems to be tied to `biguint` right now.
- The `from_...` methods currently require an extra copy by taking ownership of a `Vec<u8>`. Should this be avoided before it's merged?