### PR TITLE
Scalar operations across all integer types

### DIFF
--- a/bigint/src/algorithms.rs
+++ b/bigint/src/algorithms.rs
@@ -433,7 +433,7 @@ pub fn div_rem(u: &BigUint, d: &BigUint) -> (BigUint, BigUint) {
     // q0, our guess, is calculated by dividing the last few digits of a by the last digit of b
     // - this should give us a guess that is "close" to the actual quotient, but is possibly
     // greater than the actual quotient. If q0 * b > a, we simply use iterated subtraction
-    // until we have a guess such that q0 & b <= a.
+    // until we have a guess such that q0 * b <= a.
     //
 
     let bn = *b.data.last().unwrap();

--- a/bigint/src/algorithms.rs
+++ b/bigint/src/algorithms.rs
@@ -85,6 +85,15 @@ pub fn mac_with_carry(a: BigDigit, b: BigDigit, c: BigDigit, carry: &mut BigDigi
     lo
 }
 
+#[inline]
+pub fn mul_with_carry(a: BigDigit, b: BigDigit, carry: &mut BigDigit) -> BigDigit {
+    let (hi, lo) = big_digit::from_doublebigdigit((a as DoubleBigDigit) * (b as DoubleBigDigit) +
+                                                  (*carry as DoubleBigDigit));
+
+    *carry = hi;
+    lo
+}
+
 /// Divide a two digit numerator by a one digit divisor, returns quotient and remainder:
 ///
 /// Note: the caller must ensure that both the quotient and remainder will fit into a single digit.
@@ -375,6 +384,14 @@ pub fn mul3(x: &[BigDigit], y: &[BigDigit]) -> BigUint {
 
     mac3(&mut prod.data[..], x, y);
     prod.normalize()
+}
+
+pub fn scalar_mul(a: &mut [BigDigit], b: BigDigit) -> BigDigit {
+    let mut carry = 0;
+    for a in a.iter_mut() {
+        *a = mul_with_carry(*a, b, &mut carry);
+    }
+    carry
 }
 
 pub fn div_rem(u: &BigUint, d: &BigUint) -> (BigUint, BigUint) {

--- a/bigint/src/bigint.rs
+++ b/bigint/src/bigint.rs
@@ -508,6 +508,26 @@ impl<'a, 'b> Div<&'b BigInt> for &'a BigInt {
     }
 }
 
+forward_all_scalar_binop_to_val_val!(impl Div<BigDigit> for BigInt, div);
+
+impl Div<BigDigit> for BigInt {
+    type Output = BigInt;
+
+    #[inline]
+    fn div(self, other: BigDigit) -> BigInt {
+        BigInt::from_biguint(self.sign, self.data / other)
+    }
+}
+
+impl Div<BigInt> for BigDigit {
+    type Output = BigInt;
+
+    #[inline]
+    fn div(self, other: BigInt) -> BigInt {
+        BigInt::from_biguint(other.sign, self / other.data)
+    }
+}
+
 forward_all_binop_to_ref_ref!(impl Rem for BigInt, rem);
 
 impl<'a, 'b> Rem<&'b BigInt> for &'a BigInt {
@@ -517,6 +537,26 @@ impl<'a, 'b> Rem<&'b BigInt> for &'a BigInt {
     fn rem(self, other: &BigInt) -> BigInt {
         let (_, r) = self.div_rem(other);
         r
+    }
+}
+
+forward_all_scalar_binop_to_val_val!(impl Rem<BigDigit> for BigInt, rem);
+
+impl Rem<BigDigit> for BigInt {
+    type Output = BigInt;
+
+    #[inline]
+    fn rem(self, other: BigDigit) -> BigInt {
+        BigInt::from_biguint(self.sign, self.data % other)
+    }
+}
+
+impl Rem<BigInt> for BigDigit {
+    type Output = BigInt;
+
+    #[inline]
+    fn rem(self, other: BigInt) -> BigInt {
+        BigInt::from_biguint(Plus, self % other.data)
     }
 }
 

--- a/bigint/src/bigint.rs
+++ b/bigint/src/bigint.rs
@@ -299,6 +299,14 @@ impl Signed for BigInt {
     }
 }
 
+// A convenience method for getting the absolute value of an i32 in a u32.
+fn i32_abs_as_u32(a: i32) -> u32 {
+    match a.checked_abs() {
+        Some(x) => x as u32,
+        None => a as u32
+    }
+}
+
 // We want to forward to BigUint::add, but it's not clear how that will go until
 // we compare both sign and magnitude.  So we duplicate this body for every
 // val/ref combination, deferring that decision to BigUint's own forwarding.
@@ -378,6 +386,21 @@ impl Add<BigDigit> for BigInt {
                     Less => BigInt::from_biguint(Plus, other - self.data),
                     Greater => BigInt::from_biguint(Minus, self.data - other),
                 }
+        }
+    }
+}
+
+forward_all_scalar_binop_to_val_val_commutative!(impl Add<i32> for BigInt, add);
+
+impl Add<i32> for BigInt {
+    type Output = BigInt;
+
+    #[inline]
+    fn add(self, other: i32) -> BigInt {
+        if other >= 0 {
+            self + other as u32
+        } else {
+            self - i32_abs_as_u32(other)
         }
     }
 }
@@ -474,6 +497,34 @@ impl Sub<BigInt> for BigDigit {
     }
 }
 
+forward_all_scalar_binop_to_val_val!(impl Sub<i32> for BigInt, sub);
+
+impl Sub<i32> for BigInt {
+    type Output = BigInt;
+
+    #[inline]
+    fn sub(self, other: i32) -> BigInt {
+        if other >= 0 {
+            self - other as u32
+        } else {
+            self + i32_abs_as_u32(other)
+        }
+    }
+}
+
+impl Sub<BigInt> for i32 {
+    type Output = BigInt;
+
+    #[inline]
+    fn sub(self, other: BigInt) -> BigInt {
+        if self >= 0 {
+            self as u32 - other
+        } else {
+            -other - i32_abs_as_u32(self)
+        }
+    }
+}
+
 forward_all_binop_to_ref_ref!(impl Mul for BigInt, mul);
 
 impl<'a, 'b> Mul<&'b BigInt> for &'a BigInt {
@@ -493,6 +544,21 @@ impl Mul<BigDigit> for BigInt {
     #[inline]
     fn mul(self, other: BigDigit) -> BigInt {
         BigInt::from_biguint(self.sign, self.data * other)
+    }
+}
+
+forward_all_scalar_binop_to_val_val_commutative!(impl Mul<i32> for BigInt, mul);
+
+impl Mul<i32> for BigInt {
+    type Output = BigInt;
+
+    #[inline]
+    fn mul(self, other: i32) -> BigInt {
+        if other >= 0 {
+            self * other as u32
+        } else {
+            -(self * i32_abs_as_u32(other))
+        }
     }
 }
 
@@ -528,6 +594,34 @@ impl Div<BigInt> for BigDigit {
     }
 }
 
+forward_all_scalar_binop_to_val_val!(impl Div<i32> for BigInt, div);
+
+impl Div<i32> for BigInt {
+    type Output = BigInt;
+
+    #[inline]
+    fn div(self, other: i32) -> BigInt {
+        if other >= 0 {
+            self / other as u32
+        } else {
+            -(self / i32_abs_as_u32(other))
+        }
+    }
+}
+
+impl Div<BigInt> for i32 {
+    type Output = BigInt;
+
+    #[inline]
+    fn div(self, other: BigInt) -> BigInt {
+        if self >= 0 {
+            self as u32 / other
+        } else {
+            -(i32_abs_as_u32(self) / other)
+        }
+    }
+}
+
 forward_all_binop_to_ref_ref!(impl Rem for BigInt, rem);
 
 impl<'a, 'b> Rem<&'b BigInt> for &'a BigInt {
@@ -557,6 +651,34 @@ impl Rem<BigInt> for BigDigit {
     #[inline]
     fn rem(self, other: BigInt) -> BigInt {
         BigInt::from_biguint(Plus, self % other.data)
+    }
+}
+
+forward_all_scalar_binop_to_val_val!(impl Rem<i32> for BigInt, rem);
+
+impl Rem<i32> for BigInt {
+    type Output = BigInt;
+
+    #[inline]
+    fn rem(self, other: i32) -> BigInt {
+        if other >= 0 {
+            self % other as u32
+        } else {
+            self % i32_abs_as_u32(other)
+        }
+    }
+}
+
+impl Rem<BigInt> for i32 {
+    type Output = BigInt;
+
+    #[inline]
+    fn rem(self, other: BigInt) -> BigInt {
+        if self >= 0 {
+            self as u32 % other
+        } else {
+            -(i32_abs_as_u32(self) % other)
+        }
     }
 }
 

--- a/bigint/src/bigint.rs
+++ b/bigint/src/bigint.rs
@@ -28,6 +28,9 @@ use biguint;
 use biguint::to_str_radix_reversed;
 use biguint::BigUint;
 
+use UsizePromotion;
+use IsizePromotion;
+
 #[cfg(test)]
 #[path = "tests/bigint.rs"]
 mod bigint_tests;
@@ -301,17 +304,19 @@ impl Signed for BigInt {
 
 // A convenience method for getting the absolute value of an i32 in a u32.
 fn i32_abs_as_u32(a: i32) -> u32 {
-    match a.checked_abs() {
-        Some(x) => x as u32,
-        None => a as u32
+    if a == i32::min_value() {
+        a as u32
+    } else {
+        a.abs() as u32
     }
 }
 
 // A convenience method for getting the absolute value of an i64 in a u64.
 fn i64_abs_as_u64(a: i64) -> u64 {
-    match a.checked_abs() {
-        Some(x) => x as u64,
-        None => a as u64
+    if a == i64::min_value() {
+        a as u64
+    } else {
+        a.abs() as u64
     }
 }
 

--- a/bigint/src/bigint.rs
+++ b/bigint/src/bigint.rs
@@ -445,6 +445,35 @@ impl Sub<BigInt> for BigInt {
     }
 }
 
+forward_all_scalar_binop_to_val_val!(impl Sub<BigDigit> for BigInt, sub);
+
+impl Sub<BigDigit> for BigInt {
+    type Output = BigInt;
+
+    #[inline]
+    fn sub(self, other: BigDigit) -> BigInt {
+        match self.sign {
+            NoSign => BigInt::from_biguint(Minus, From::from(other)),
+            Minus => BigInt::from_biguint(Minus, self.data + other),
+            Plus =>
+                match self.data.cmp(&From::from(other)) {
+                    Equal => Zero::zero(),
+                    Greater => BigInt::from_biguint(Plus, self.data - other),
+                    Less => BigInt::from_biguint(Minus, other - self.data),
+                }
+        }
+    }
+}
+
+impl Sub<BigInt> for BigDigit {
+    type Output = BigInt;
+
+    #[inline]
+    fn sub(self, other: BigInt) -> BigInt {
+        -(other - self)
+    }
+}
+
 forward_all_binop_to_ref_ref!(impl Mul for BigInt, mul);
 
 impl<'a, 'b> Mul<&'b BigInt> for &'a BigInt {

--- a/bigint/src/bigint.rs
+++ b/bigint/src/bigint.rs
@@ -485,6 +485,8 @@ impl<'a, 'b> Mul<&'b BigInt> for &'a BigInt {
     }
 }
 
+forward_all_scalar_binop_to_val_val_commutative!(impl Mul<BigDigit> for BigInt, mul);
+
 impl Mul<BigDigit> for BigInt {
     type Output = BigInt;
 

--- a/bigint/src/bigint.rs
+++ b/bigint/src/bigint.rs
@@ -370,6 +370,7 @@ impl Add<BigInt> for BigInt {
     }
 }
 
+promote_all_scalars!(impl Add for BigInt, add);
 forward_all_scalar_binop_to_val_val_commutative!(impl Add<BigDigit> for BigInt, add);
 
 impl Add<BigDigit> for BigInt {
@@ -468,6 +469,7 @@ impl Sub<BigInt> for BigInt {
     }
 }
 
+promote_all_scalars!(impl Sub for BigInt, sub);
 forward_all_scalar_binop_to_val_val!(impl Sub<BigDigit> for BigInt, sub);
 
 impl Sub<BigDigit> for BigInt {
@@ -536,6 +538,7 @@ impl<'a, 'b> Mul<&'b BigInt> for &'a BigInt {
     }
 }
 
+promote_all_scalars!(impl Mul for BigInt, mul);
 forward_all_scalar_binop_to_val_val_commutative!(impl Mul<BigDigit> for BigInt, mul);
 
 impl Mul<BigDigit> for BigInt {
@@ -574,6 +577,7 @@ impl<'a, 'b> Div<&'b BigInt> for &'a BigInt {
     }
 }
 
+promote_all_scalars!(impl Div for BigInt, div);
 forward_all_scalar_binop_to_val_val!(impl Div<BigDigit> for BigInt, div);
 
 impl Div<BigDigit> for BigInt {
@@ -634,6 +638,7 @@ impl<'a, 'b> Rem<&'b BigInt> for &'a BigInt {
     }
 }
 
+promote_all_scalars!(impl Rem for BigInt, rem);
 forward_all_scalar_binop_to_val_val!(impl Rem<BigDigit> for BigInt, rem);
 
 impl Rem<BigDigit> for BigInt {

--- a/bigint/src/bigint.rs
+++ b/bigint/src/bigint.rs
@@ -436,6 +436,15 @@ impl<'a, 'b> Mul<&'b BigInt> for &'a BigInt {
     }
 }
 
+impl Mul<BigDigit> for BigInt {
+    type Output = BigInt;
+
+    #[inline]
+    fn mul(self, other: BigDigit) -> BigInt {
+        BigInt::from_biguint(self.sign, self.data * other)
+    }
+}
+
 forward_all_binop_to_ref_ref!(impl Div for BigInt, div);
 
 impl<'a, 'b> Div<&'b BigInt> for &'a BigInt {

--- a/bigint/src/bigint.rs
+++ b/bigint/src/bigint.rs
@@ -362,6 +362,26 @@ impl Add<BigInt> for BigInt {
     }
 }
 
+forward_all_scalar_binop_to_val_val_commutative!(impl Add<BigDigit> for BigInt, add);
+
+impl Add<BigDigit> for BigInt {
+    type Output = BigInt;
+
+    #[inline]
+    fn add(self, other: BigDigit) -> BigInt {
+        match self.sign {
+            NoSign => From::from(other),
+            Plus => BigInt::from_biguint(Plus, self.data + other),
+            Minus =>
+                match self.data.cmp(&From::from(other)) {
+                    Equal => Zero::zero(),
+                    Less => BigInt::from_biguint(Plus, other - self.data),
+                    Greater => BigInt::from_biguint(Minus, self.data - other),
+                }
+        }
+    }
+}
+
 // We want to forward to BigUint::sub, but it's not clear how that will go until
 // we compare both sign and magnitude.  So we duplicate this body for every
 // val/ref combination, deferring that decision to BigUint's own forwarding.

--- a/bigint/src/bigint.rs
+++ b/bigint/src/bigint.rs
@@ -303,6 +303,7 @@ impl Signed for BigInt {
 }
 
 // A convenience method for getting the absolute value of an i32 in a u32.
+#[inline]
 fn i32_abs_as_u32(a: i32) -> u32 {
     if a == i32::min_value() {
         a as u32
@@ -312,6 +313,7 @@ fn i32_abs_as_u32(a: i32) -> u32 {
 }
 
 // A convenience method for getting the absolute value of an i64 in a u64.
+#[inline]
 fn i64_abs_as_u64(a: i64) -> u64 {
     if a == i64::min_value() {
         a as u64

--- a/bigint/src/bigint.rs
+++ b/bigint/src/bigint.rs
@@ -23,7 +23,7 @@ use self::Sign::{Minus, NoSign, Plus};
 
 use super::ParseBigIntError;
 use super::big_digit;
-use super::big_digit::BigDigit;
+use super::big_digit::{BigDigit, DoubleBigDigit};
 use biguint;
 use biguint::to_str_radix_reversed;
 use biguint::BigUint;
@@ -307,6 +307,14 @@ fn i32_abs_as_u32(a: i32) -> u32 {
     }
 }
 
+// A convenience method for getting the absolute value of an i64 in a u64.
+fn i64_abs_as_u64(a: i64) -> u64 {
+    match a.checked_abs() {
+        Some(x) => x as u64,
+        None => a as u64
+    }
+}
+
 // We want to forward to BigUint::add, but it's not clear how that will go until
 // we compare both sign and magnitude.  So we duplicate this body for every
 // val/ref combination, deferring that decision to BigUint's own forwarding.
@@ -372,6 +380,7 @@ impl Add<BigInt> for BigInt {
 
 promote_all_scalars!(impl Add for BigInt, add);
 forward_all_scalar_binop_to_val_val_commutative!(impl Add<BigDigit> for BigInt, add);
+forward_all_scalar_binop_to_val_val_commutative!(impl Add<DoubleBigDigit> for BigInt, add);
 
 impl Add<BigDigit> for BigInt {
     type Output = BigInt;
@@ -391,7 +400,26 @@ impl Add<BigDigit> for BigInt {
     }
 }
 
+impl Add<DoubleBigDigit> for BigInt {
+    type Output = BigInt;
+
+    #[inline]
+    fn add(self, other: DoubleBigDigit) -> BigInt {
+        match self.sign {
+            NoSign => From::from(other),
+            Plus => BigInt::from_biguint(Plus, self.data + other),
+            Minus =>
+                match self.data.cmp(&From::from(other)) {
+                    Equal => Zero::zero(),
+                    Less => BigInt::from_biguint(Plus, other - self.data),
+                    Greater => BigInt::from_biguint(Minus, self.data - other),
+                }
+        }
+    }
+}
+
 forward_all_scalar_binop_to_val_val_commutative!(impl Add<i32> for BigInt, add);
+forward_all_scalar_binop_to_val_val_commutative!(impl Add<i64> for BigInt, add);
 
 impl Add<i32> for BigInt {
     type Output = BigInt;
@@ -402,6 +430,19 @@ impl Add<i32> for BigInt {
             self + other as u32
         } else {
             self - i32_abs_as_u32(other)
+        }
+    }
+}
+
+impl Add<i64> for BigInt {
+    type Output = BigInt;
+
+    #[inline]
+    fn add(self, other: i64) -> BigInt {
+        if other >= 0 {
+            self + other as u64
+        } else {
+            self - i64_abs_as_u64(other)
         }
     }
 }
@@ -471,6 +512,7 @@ impl Sub<BigInt> for BigInt {
 
 promote_all_scalars!(impl Sub for BigInt, sub);
 forward_all_scalar_binop_to_val_val!(impl Sub<BigDigit> for BigInt, sub);
+forward_all_scalar_binop_to_val_val!(impl Sub<DoubleBigDigit> for BigInt, sub);
 
 impl Sub<BigDigit> for BigInt {
     type Output = BigInt;
@@ -499,7 +541,35 @@ impl Sub<BigInt> for BigDigit {
     }
 }
 
+impl Sub<DoubleBigDigit> for BigInt {
+    type Output = BigInt;
+
+    #[inline]
+    fn sub(self, other: DoubleBigDigit) -> BigInt {
+        match self.sign {
+            NoSign => BigInt::from_biguint(Minus, From::from(other)),
+            Minus => BigInt::from_biguint(Minus, self.data + other),
+            Plus =>
+                match self.data.cmp(&From::from(other)) {
+                    Equal => Zero::zero(),
+                    Greater => BigInt::from_biguint(Plus, self.data - other),
+                    Less => BigInt::from_biguint(Minus, other - self.data),
+                }
+        }
+    }
+}
+
+impl Sub<BigInt> for DoubleBigDigit {
+    type Output = BigInt;
+
+    #[inline]
+    fn sub(self, other: BigInt) -> BigInt {
+        -(other - self)
+    }
+}
+
 forward_all_scalar_binop_to_val_val!(impl Sub<i32> for BigInt, sub);
+forward_all_scalar_binop_to_val_val!(impl Sub<i64> for BigInt, sub);
 
 impl Sub<i32> for BigInt {
     type Output = BigInt;
@@ -527,6 +597,32 @@ impl Sub<BigInt> for i32 {
     }
 }
 
+impl Sub<i64> for BigInt {
+    type Output = BigInt;
+
+    #[inline]
+    fn sub(self, other: i64) -> BigInt {
+        if other >= 0 {
+            self - other as u64
+        } else {
+            self + i64_abs_as_u64(other)
+        }
+    }
+}
+
+impl Sub<BigInt> for i64 {
+    type Output = BigInt;
+
+    #[inline]
+    fn sub(self, other: BigInt) -> BigInt {
+        if self >= 0 {
+            self as u64 - other
+        } else {
+            -other - i64_abs_as_u64(self)
+        }
+    }
+}
+
 forward_all_binop_to_ref_ref!(impl Mul for BigInt, mul);
 
 impl<'a, 'b> Mul<&'b BigInt> for &'a BigInt {
@@ -540,6 +636,7 @@ impl<'a, 'b> Mul<&'b BigInt> for &'a BigInt {
 
 promote_all_scalars!(impl Mul for BigInt, mul);
 forward_all_scalar_binop_to_val_val_commutative!(impl Mul<BigDigit> for BigInt, mul);
+forward_all_scalar_binop_to_val_val_commutative!(impl Mul<DoubleBigDigit> for BigInt, mul);
 
 impl Mul<BigDigit> for BigInt {
     type Output = BigInt;
@@ -550,7 +647,17 @@ impl Mul<BigDigit> for BigInt {
     }
 }
 
+impl Mul<DoubleBigDigit> for BigInt {
+    type Output = BigInt;
+
+    #[inline]
+    fn mul(self, other: DoubleBigDigit) -> BigInt {
+        BigInt::from_biguint(self.sign, self.data * other)
+    }
+}
+
 forward_all_scalar_binop_to_val_val_commutative!(impl Mul<i32> for BigInt, mul);
+forward_all_scalar_binop_to_val_val_commutative!(impl Mul<i64> for BigInt, mul);
 
 impl Mul<i32> for BigInt {
     type Output = BigInt;
@@ -561,6 +668,19 @@ impl Mul<i32> for BigInt {
             self * other as u32
         } else {
             -(self * i32_abs_as_u32(other))
+        }
+    }
+}
+
+impl Mul<i64> for BigInt {
+    type Output = BigInt;
+
+    #[inline]
+    fn mul(self, other: i64) -> BigInt {
+        if other >= 0 {
+            self * other as u64
+        } else {
+            -(self * i64_abs_as_u64(other))
         }
     }
 }
@@ -579,6 +699,7 @@ impl<'a, 'b> Div<&'b BigInt> for &'a BigInt {
 
 promote_all_scalars!(impl Div for BigInt, div);
 forward_all_scalar_binop_to_val_val!(impl Div<BigDigit> for BigInt, div);
+forward_all_scalar_binop_to_val_val!(impl Div<DoubleBigDigit> for BigInt, div);
 
 impl Div<BigDigit> for BigInt {
     type Output = BigInt;
@@ -598,7 +719,26 @@ impl Div<BigInt> for BigDigit {
     }
 }
 
+impl Div<DoubleBigDigit> for BigInt {
+    type Output = BigInt;
+
+    #[inline]
+    fn div(self, other: DoubleBigDigit) -> BigInt {
+        BigInt::from_biguint(self.sign, self.data / other)
+    }
+}
+
+impl Div<BigInt> for DoubleBigDigit {
+    type Output = BigInt;
+
+    #[inline]
+    fn div(self, other: BigInt) -> BigInt {
+        BigInt::from_biguint(other.sign, self / other.data)
+    }
+}
+
 forward_all_scalar_binop_to_val_val!(impl Div<i32> for BigInt, div);
+forward_all_scalar_binop_to_val_val!(impl Div<i64> for BigInt, div);
 
 impl Div<i32> for BigInt {
     type Output = BigInt;
@@ -626,6 +766,32 @@ impl Div<BigInt> for i32 {
     }
 }
 
+impl Div<i64> for BigInt {
+    type Output = BigInt;
+
+    #[inline]
+    fn div(self, other: i64) -> BigInt {
+        if other >= 0 {
+            self / other as u64
+        } else {
+            -(self / i64_abs_as_u64(other))
+        }
+    }
+}
+
+impl Div<BigInt> for i64 {
+    type Output = BigInt;
+
+    #[inline]
+    fn div(self, other: BigInt) -> BigInt {
+        if self >= 0 {
+            self as u64 / other
+        } else {
+            -(i64_abs_as_u64(self) / other)
+        }
+    }
+}
+
 forward_all_binop_to_ref_ref!(impl Rem for BigInt, rem);
 
 impl<'a, 'b> Rem<&'b BigInt> for &'a BigInt {
@@ -640,6 +806,7 @@ impl<'a, 'b> Rem<&'b BigInt> for &'a BigInt {
 
 promote_all_scalars!(impl Rem for BigInt, rem);
 forward_all_scalar_binop_to_val_val!(impl Rem<BigDigit> for BigInt, rem);
+forward_all_scalar_binop_to_val_val!(impl Rem<DoubleBigDigit> for BigInt, rem);
 
 impl Rem<BigDigit> for BigInt {
     type Output = BigInt;
@@ -659,7 +826,26 @@ impl Rem<BigInt> for BigDigit {
     }
 }
 
+impl Rem<DoubleBigDigit> for BigInt {
+    type Output = BigInt;
+
+    #[inline]
+    fn rem(self, other: DoubleBigDigit) -> BigInt {
+        BigInt::from_biguint(self.sign, self.data % other)
+    }
+}
+
+impl Rem<BigInt> for DoubleBigDigit {
+    type Output = BigInt;
+
+    #[inline]
+    fn rem(self, other: BigInt) -> BigInt {
+        BigInt::from_biguint(Plus, self % other.data)
+    }
+}
+
 forward_all_scalar_binop_to_val_val!(impl Rem<i32> for BigInt, rem);
+forward_all_scalar_binop_to_val_val!(impl Rem<i64> for BigInt, rem);
 
 impl Rem<i32> for BigInt {
     type Output = BigInt;
@@ -683,6 +869,32 @@ impl Rem<BigInt> for i32 {
             self as u32 % other
         } else {
             -(i32_abs_as_u32(self) % other)
+        }
+    }
+}
+
+impl Rem<i64> for BigInt {
+    type Output = BigInt;
+
+    #[inline]
+    fn rem(self, other: i64) -> BigInt {
+        if other >= 0 {
+            self % other as u64
+        } else {
+            self % i64_abs_as_u64(other)
+        }
+    }
+}
+
+impl Rem<BigInt> for i64 {
+    type Output = BigInt;
+
+    #[inline]
+    fn rem(self, other: BigInt) -> BigInt {
+        if self >= 0 {
+            self as u64 % other
+        } else {
+            -(i64_abs_as_u64(self) % other)
         }
     }
 }

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -519,8 +519,7 @@ impl Div<BigUint> for BigDigit {
     type Output = BigUint;
 
     #[inline]
-    fn div(self, mut other: BigUint) -> BigUint {
-        other = other.normalize();
+    fn div(self, other: BigUint) -> BigUint {
         match other.data.len() {
             0 => panic!(),
             1 => From::from(self / other.data[0]),
@@ -557,8 +556,7 @@ impl Rem<BigUint> for BigDigit {
     type Output = BigUint;
 
     #[inline]
-    fn rem(self, mut other: BigUint) -> BigUint {
-        other = other.normalize();
+    fn rem(self, other: BigUint) -> BigUint {
         match other.data.len() {
             0 => panic!(),
             1 => From::from(self % other.data[0]),

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -429,7 +429,7 @@ impl Add<DoubleBigDigit> for BigUint {
             self.data.push(0);
         }
 
-        let (lo, hi) = big_digit::from_doublebigdigit(other);
+        let (hi, lo) = big_digit::from_doublebigdigit(other);
         let carry = __add2(&mut self.data, &[lo, hi]);
         if carry != 0 {
             self.data.push(carry);
@@ -497,7 +497,7 @@ impl Sub<DoubleBigDigit> for BigUint {
 
     #[inline]
     fn sub(mut self, other: DoubleBigDigit) -> BigUint {
-        let (lo, hi) = big_digit::from_doublebigdigit(other);
+        let (hi, lo) = big_digit::from_doublebigdigit(other);
         sub2(&mut self.data[..], &[lo, hi]);
         self.normalize()
     }
@@ -512,7 +512,7 @@ impl Sub<BigUint> for DoubleBigDigit {
             other.data.push(0);
         }
 
-        let (lo, hi) = big_digit::from_doublebigdigit(self);
+        let (hi, lo) = big_digit::from_doublebigdigit(self);
         sub2rev(&[lo, hi], &mut other.data[..]);
         other.normalize()
     }
@@ -561,7 +561,7 @@ impl Mul<DoubleBigDigit> for BigUint {
         } else if other <= BigDigit::max_value() as DoubleBigDigit {
             self * other as BigDigit
         } else {
-            let (lo, hi) = big_digit::from_doublebigdigit(other);
+            let (hi, lo) = big_digit::from_doublebigdigit(other);
             mul3(&self.data[..], &[lo, hi])
         }
     }
@@ -624,7 +624,7 @@ impl Div<BigUint> for DoubleBigDigit {
         match other.data.len() {
             0 => panic!(),
             1 => From::from(self / other.data[0] as u64),
-            2 => From::from(self / big_digit::to_doublebigdigit(other.data[0], other.data[1])),
+            2 => From::from(self / big_digit::to_doublebigdigit(other.data[1], other.data[0])),
             _ => Zero::zero(),
         }
     }

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -22,7 +22,7 @@ mod algorithms;
 pub use self::algorithms::big_digit;
 pub use self::big_digit::{BigDigit, DoubleBigDigit, ZERO_BIG_DIGIT};
 
-use self::algorithms::{mac_with_carry, mul3, div_rem, div_rem_digit};
+use self::algorithms::{mac_with_carry, mul3, scalar_mul, div_rem, div_rem_digit};
 use self::algorithms::{__add2, add2, sub2, sub2rev};
 use self::algorithms::{biguint_shl, biguint_shr};
 use self::algorithms::{cmp_slice, fls, ilog2};
@@ -428,6 +428,19 @@ impl<'a, 'b> Mul<&'b BigUint> for &'a BigUint {
     #[inline]
     fn mul(self, other: &BigUint) -> BigUint {
         mul3(&self.data[..], &other.data[..])
+    }
+}
+
+impl Mul<BigDigit> for BigUint {
+    type Output = BigUint;
+
+    #[inline]
+    fn mul(mut self, other: BigDigit) -> BigUint {
+        let carry = scalar_mul(&mut self.data[..], other);
+        if carry != 0 {
+            self.data.push(carry);
+        }
+        self
     }
 }
 

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -483,9 +483,13 @@ impl Mul<BigDigit> for BigUint {
 
     #[inline]
     fn mul(mut self, other: BigDigit) -> BigUint {
-        let carry = scalar_mul(&mut self.data[..], other);
-        if carry != 0 {
-            self.data.push(carry);
+        if other == 0 {
+            self.data.clear();
+        } else {
+            let carry = scalar_mul(&mut self.data[..], other);
+            if carry != 0 {
+                self.data.push(carry);
+            }
         }
         self
     }

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -27,6 +27,8 @@ use self::algorithms::{__add2, add2, sub2, sub2rev};
 use self::algorithms::{biguint_shl, biguint_shr};
 use self::algorithms::{cmp_slice, fls, ilog2};
 
+use UsizePromotion;
+
 use ParseBigIntError;
 
 #[cfg(test)]

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -394,7 +394,7 @@ impl<'a> Add<&'a BigUint> for BigUint {
     }
 }
 
-forward_all_scalar_binop_to_val_val!(impl Add<BigDigit> for BigUint, add);
+forward_all_scalar_binop_to_val_val_commutative!(impl Add<BigDigit> for BigUint, add);
 
 impl Add<BigDigit> for BigUint {
     type Output = BigUint;
@@ -460,7 +460,7 @@ impl<'a, 'b> Mul<&'b BigUint> for &'a BigUint {
     }
 }
 
-forward_all_scalar_binop_to_val_val!(impl Mul<BigDigit> for BigUint, mul);
+forward_all_scalar_binop_to_val_val_commutative!(impl Mul<BigDigit> for BigUint, mul);
 
 impl Mul<BigDigit> for BigUint {
     type Output = BigUint;

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -479,7 +479,17 @@ impl<'a, 'b> Div<&'b BigUint> for &'a BigUint {
     #[inline]
     fn div(self, other: &BigUint) -> BigUint {
         let (q, _) = self.div_rem(other);
-        return q;
+        q
+    }
+}
+
+impl Div<BigDigit> for BigUint {
+    type Output = BigUint;
+
+    #[inline]
+    fn div(self, other: BigDigit) -> BigUint {
+        let (q, _) = div_rem_digit(self, other);
+        q
     }
 }
 
@@ -491,7 +501,17 @@ impl<'a, 'b> Rem<&'b BigUint> for &'a BigUint {
     #[inline]
     fn rem(self, other: &BigUint) -> BigUint {
         let (_, r) = self.div_rem(other);
-        return r;
+        r
+    }
+}
+
+impl Rem<BigDigit> for BigUint {
+    type Output = BigDigit;
+
+    #[inline]
+    fn rem(self, other: BigDigit) -> BigDigit {
+        let (_, r) = div_rem_digit(self, other);
+        r
     }
 }
 

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -439,6 +439,8 @@ impl<'a> Sub<BigUint> for &'a BigUint {
     }
 }
 
+forward_all_scalar_binop_to_val_val!(impl Sub<BigDigit> for BigUint, sub);
+
 impl Sub<BigDigit> for BigUint {
     type Output = BigUint;
 
@@ -446,6 +448,20 @@ impl Sub<BigDigit> for BigUint {
     fn sub(mut self, other: BigDigit) -> BigUint {
         sub2(&mut self.data[..], &[other]);
         self.normalize()
+    }
+}
+
+impl Sub<BigUint> for BigDigit {
+    type Output = BigUint;
+
+    #[inline]
+    fn sub(self, mut other: BigUint) -> BigUint {
+        if other.data.len() == 0 {
+            other.data.push(0);
+        }
+
+        sub2rev(&[self], &mut other.data[..]);
+        other.normalize()
     }
 }
 

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -402,7 +402,7 @@ impl Add<BigDigit> for BigUint {
 
     #[inline]
     fn add(mut self, other: BigDigit) -> BigUint {
-        if self.data.len() == 0 {
+        if self.data.len() == 0 && other != 0 {
             self.data.push(0);
         }
 

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -405,13 +405,15 @@ impl Add<BigDigit> for BigUint {
 
     #[inline]
     fn add(mut self, other: BigDigit) -> BigUint {
-        if self.data.len() == 0 && other != 0 {
-            self.data.push(0);
-        }
+        if other != 0 {
+            if self.data.len() == 0 {
+                self.data.push(0);
+            }
 
-        let carry = __add2(&mut self.data, &[other]);
-        if carry != 0 {
-            self.data.push(carry);
+            let carry = __add2(&mut self.data, &[other]);
+            if carry != 0 {
+                self.data.push(carry);
+            }
         }
         self
     }
@@ -422,19 +424,20 @@ impl Add<DoubleBigDigit> for BigUint {
 
     #[inline]
     fn add(mut self, other: DoubleBigDigit) -> BigUint {
-        if self.data.len() == 0 && other != 0 {
-            self.data.push(0);
-        }
-        if self.data.len() == 1 && other > BigDigit::max_value() as DoubleBigDigit {
-            self.data.push(0);
-        }
-
         let (hi, lo) = big_digit::from_doublebigdigit(other);
-        let carry = __add2(&mut self.data, &[lo, hi]);
-        if carry != 0 {
-            self.data.push(carry);
+        if hi == 0 {
+            self + lo
+        } else {
+            while self.data.len() < 2 {
+                self.data.push(0);
+            }
+
+            let carry = __add2(&mut self.data, &[lo, hi]);
+            if carry != 0 {
+                self.data.push(carry);
+            }
+            self
         }
-        self
     }
 }
 

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -394,6 +394,7 @@ impl<'a> Add<&'a BigUint> for BigUint {
     }
 }
 
+promote_unsigned_scalars!(impl Add for BigUint, add);
 forward_all_scalar_binop_to_val_val_commutative!(impl Add<BigDigit> for BigUint, add);
 
 impl Add<BigDigit> for BigUint {
@@ -439,6 +440,7 @@ impl<'a> Sub<BigUint> for &'a BigUint {
     }
 }
 
+promote_unsigned_scalars!(impl Sub for BigUint, sub);
 forward_all_scalar_binop_to_val_val!(impl Sub<BigDigit> for BigUint, sub);
 
 impl Sub<BigDigit> for BigUint {
@@ -476,6 +478,7 @@ impl<'a, 'b> Mul<&'b BigUint> for &'a BigUint {
     }
 }
 
+promote_unsigned_scalars!(impl Mul for BigUint, mul);
 forward_all_scalar_binop_to_val_val_commutative!(impl Mul<BigDigit> for BigUint, mul);
 
 impl Mul<BigDigit> for BigUint {
@@ -507,6 +510,7 @@ impl<'a, 'b> Div<&'b BigUint> for &'a BigUint {
     }
 }
 
+promote_unsigned_scalars!(impl Div for BigUint, div);
 forward_all_scalar_binop_to_val_val!(impl Div<BigDigit> for BigUint, div);
 
 impl Div<BigDigit> for BigUint {
@@ -544,6 +548,7 @@ impl<'a, 'b> Rem<&'b BigUint> for &'a BigUint {
     }
 }
 
+promote_unsigned_scalars!(impl Rem for BigUint, rem);
 forward_all_scalar_binop_to_val_val!(impl Rem<BigDigit> for BigUint, rem);
 
 impl Rem<BigDigit> for BigUint {

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -503,6 +503,8 @@ impl<'a, 'b> Div<&'b BigUint> for &'a BigUint {
     }
 }
 
+forward_all_scalar_binop_to_val_val!(impl Div<BigDigit> for BigUint, div);
+
 impl Div<BigDigit> for BigUint {
     type Output = BigUint;
 
@@ -510,6 +512,20 @@ impl Div<BigDigit> for BigUint {
     fn div(self, other: BigDigit) -> BigUint {
         let (q, _) = div_rem_digit(self, other);
         q
+    }
+}
+
+impl Div<BigUint> for BigDigit {
+    type Output = BigUint;
+
+    #[inline]
+    fn div(self, mut other: BigUint) -> BigUint {
+        other = other.normalize();
+        match other.data.len() {
+            0 => panic!(),
+            1 => From::from(self / other.data[0]),
+            _ => Zero::zero()
+        }
     }
 }
 
@@ -525,13 +541,29 @@ impl<'a, 'b> Rem<&'b BigUint> for &'a BigUint {
     }
 }
 
+forward_all_scalar_binop_to_val_val!(impl Rem<BigDigit> for BigUint, rem);
+
 impl Rem<BigDigit> for BigUint {
-    type Output = BigDigit;
+    type Output = BigUint;
 
     #[inline]
-    fn rem(self, other: BigDigit) -> BigDigit {
+    fn rem(self, other: BigDigit) -> BigUint {
         let (_, r) = div_rem_digit(self, other);
-        r
+        From::from(r)
+    }
+}
+
+impl Rem<BigUint> for BigDigit {
+    type Output = BigUint;
+
+    #[inline]
+    fn rem(self, mut other: BigUint) -> BigUint {
+        other = other.normalize();
+        match other.data.len() {
+            0 => panic!(),
+            1 => From::from(self % other.data[0]),
+            _ => other
+        }
     }
 }
 

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -437,6 +437,16 @@ impl<'a> Sub<BigUint> for &'a BigUint {
     }
 }
 
+impl Sub<BigDigit> for BigUint {
+    type Output = BigUint;
+
+    #[inline]
+    fn sub(mut self, other: BigDigit) -> BigUint {
+        sub2(&mut self.data[..], &[other]);
+        self.normalize()
+    }
+}
+
 forward_all_binop_to_ref_ref!(impl Mul for BigUint, mul);
 
 impl<'a, 'b> Mul<&'b BigUint> for &'a BigUint {

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -394,6 +394,8 @@ impl<'a> Add<&'a BigUint> for BigUint {
     }
 }
 
+forward_all_scalar_binop_to_val_val!(impl Add<BigDigit> for BigUint, add);
+
 impl Add<BigDigit> for BigUint {
     type Output = BigUint;
 

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -394,6 +394,23 @@ impl<'a> Add<&'a BigUint> for BigUint {
     }
 }
 
+impl Add<BigDigit> for BigUint {
+    type Output = BigUint;
+
+    #[inline]
+    fn add(mut self, other: BigDigit) -> BigUint {
+        if self.data.len() == 0 {
+            self.data.push(0);
+        }
+
+        let carry = __add2(&mut self.data, &[other]);
+        if carry != 0 {
+            self.data.push(carry);
+        }
+        self
+    }
+}
+
 forward_val_val_binop!(impl Sub for BigUint, sub);
 forward_ref_ref_binop!(impl Sub for BigUint, sub);
 

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -460,6 +460,8 @@ impl<'a, 'b> Mul<&'b BigUint> for &'a BigUint {
     }
 }
 
+forward_all_scalar_binop_to_val_val!(impl Mul<BigDigit> for BigUint, mul);
+
 impl Mul<BigDigit> for BigUint {
     type Output = BigUint;
 

--- a/bigint/src/lib.rs
+++ b/bigint/src/lib.rs
@@ -88,6 +88,16 @@ use std::error::Error;
 use std::num::ParseIntError;
 use std::fmt;
 
+#[cfg(target_pointer_width = "32")]
+type UsizePromotion = u32;
+#[cfg(target_pointer_width = "64")]
+type UsizePromotion = u64;
+
+#[cfg(target_pointer_width = "32")]
+type IsizePromotion = i32;
+#[cfg(target_pointer_width = "64")]
+type IsizePromotion = i64;
+
 #[derive(Debug, PartialEq)]
 pub enum ParseBigIntError {
     ParseInt(ParseIntError),

--- a/bigint/src/macros.rs
+++ b/bigint/src/macros.rs
@@ -210,35 +210,17 @@ macro_rules! promote_scalars {
     }
 }
 
-macro_rules! promote_unsigned_scalars_to_u32 {
+macro_rules! promote_unsigned_scalars {
     (impl $imp:ident for $res:ty, $method:ident) => {
-        #[cfg(target_pointer_width = "32")]
-        promote_scalars!(impl $imp<u32> for $res, $method, u8, u16, usize);
-        #[cfg(target_pointer_width = "64")]
         promote_scalars!(impl $imp<u32> for $res, $method, u8, u16);
+        promote_scalars!(impl $imp<UsizePromotion> for $res, $method, usize);
     }
 }
 
-macro_rules! promote_unsigned_scalars_to_u64 {
+macro_rules! promote_signed_scalars {
     (impl $imp:ident for $res:ty, $method:ident) => {
-        #[cfg(target_pointer_width = "64")]
-        promote_scalars!(impl $imp<u64> for $res, $method, usize);
-    }
-}
-
-macro_rules! promote_signed_scalars_to_i32 {
-    (impl $imp:ident for $res:ty, $method:ident) => {
-        #[cfg(target_pointer_width = "32")]
-        promote_scalars!(impl $imp<i32> for $res, $method, i8, i16, isize);
-        #[cfg(target_pointer_width = "64")]
         promote_scalars!(impl $imp<i32> for $res, $method, i8, i16);
-    }
-}
-
-macro_rules! promote_signed_scalars_to_i64 {
-    (impl $imp:ident for $res:ty, $method:ident) => {
-        #[cfg(target_pointer_width = "64")]
-        promote_scalars!(impl $imp<i64> for $res, $method, isize);
+        promote_scalars!(impl $imp<IsizePromotion> for $res, $method, isize);
     }
 }
 
@@ -281,20 +263,6 @@ macro_rules! forward_all_scalar_binop_to_val_val_commutative {
     (impl $imp:ident<$scalar:ty> for $res:ty, $method:ident) => {
         forward_scalar_val_val_binop_commutative!(impl $imp<$scalar> for $res, $method);
         forward_all_scalar_binop_to_val_val!(impl $imp<$scalar> for $res, $method);
-    }
-}
-
-macro_rules! promote_unsigned_scalars {
-    (impl $imp:ident for $res:ty, $method:ident) => {
-        promote_unsigned_scalars_to_u32!(impl $imp for $res, $method);
-        promote_unsigned_scalars_to_u64!(impl $imp for $res, $method);
-    }
-}
-
-macro_rules! promote_signed_scalars {
-    (impl $imp:ident for $res:ty, $method:ident) => {
-        promote_signed_scalars_to_i32!(impl $imp for $res, $method);
-        promote_signed_scalars_to_i64!(impl $imp for $res, $method);
     }
 }
 

--- a/bigint/src/macros.rs
+++ b/bigint/src/macros.rs
@@ -118,7 +118,7 @@ macro_rules! forward_scalar_val_val_binop_commutative {
     }
 }
 
-macro_rules! forward_scalar_val_ref_binop_commutative {
+macro_rules! forward_scalar_val_ref_binop {
     (impl $imp:ident<$scalar:ty> for $res:ty, $method:ident) => {
         impl<'a> $imp<&'a $scalar> for $res {
             type Output = $res;
@@ -134,13 +134,13 @@ macro_rules! forward_scalar_val_ref_binop_commutative {
 
             #[inline]
             fn $method(self, other: $res) -> $res {
-                $imp::$method(other, *self)
+                $imp::$method(*self, other)
             }
         }
     }
 }
 
-macro_rules! forward_scalar_ref_val_binop_commutative {
+macro_rules! forward_scalar_ref_val_binop {
     (impl $imp:ident<$scalar:ty> for $res:ty, $method:ident) => {
         impl<'a> $imp<$scalar> for &'a $res {
             type Output = $res;
@@ -156,13 +156,13 @@ macro_rules! forward_scalar_ref_val_binop_commutative {
 
             #[inline]
             fn $method(self, other: &$res) -> $res {
-                $imp::$method(other.clone(), self)
+                $imp::$method(self, other.clone())
             }
         }
     }
 }
 
-macro_rules! forward_scalar_ref_ref_binop_commutative {
+macro_rules! forward_scalar_ref_ref_binop {
     (impl $imp:ident<$scalar:ty> for $res:ty, $method:ident) => {
         impl<'a, 'b> $imp<&'b $scalar> for &'a $res {
             type Output = $res;
@@ -178,7 +178,7 @@ macro_rules! forward_scalar_ref_ref_binop_commutative {
 
             #[inline]
             fn $method(self, other: &$res) -> $res {
-                $imp::$method(other.clone(), *self)
+                $imp::$method(*self, other.clone())
             }
         }
     }
@@ -211,11 +211,17 @@ macro_rules! forward_all_binop_to_val_ref_commutative {
     };
 }
 
+macro_rules! forward_all_scalar_binop_to_val_val {
+    (impl $imp:ident<$scalar:ty> for $res:ty, $method:ident) => {
+        forward_scalar_val_ref_binop!(impl $imp<$scalar> for $res, $method);
+        forward_scalar_ref_val_binop!(impl $imp<$scalar> for $res, $method);
+        forward_scalar_ref_ref_binop!(impl $imp<$scalar> for $res, $method);
+    }
+}
+
 macro_rules! forward_all_scalar_binop_to_val_val_commutative {
     (impl $imp:ident<$scalar:ty> for $res:ty, $method:ident) => {
         forward_scalar_val_val_binop_commutative!(impl $imp<$scalar> for $res, $method);
-        forward_scalar_val_ref_binop_commutative!(impl $imp<$scalar> for $res, $method);
-        forward_scalar_ref_val_binop_commutative!(impl $imp<$scalar> for $res, $method);
-        forward_scalar_ref_ref_binop_commutative!(impl $imp<$scalar> for $res, $method);
+        forward_all_scalar_binop_to_val_val!(impl $imp<$scalar> for $res, $method);
     }
 }

--- a/bigint/src/macros.rs
+++ b/bigint/src/macros.rs
@@ -219,12 +219,26 @@ macro_rules! promote_unsigned_scalars_to_u32 {
     }
 }
 
+macro_rules! promote_unsigned_scalars_to_u64 {
+    (impl $imp:ident for $res:ty, $method:ident) => {
+        #[cfg(target_pointer_width = "64")]
+        promote_scalars!(impl $imp<u64> for $res, $method, usize);
+    }
+}
+
 macro_rules! promote_signed_scalars_to_i32 {
     (impl $imp:ident for $res:ty, $method:ident) => {
         #[cfg(target_pointer_width = "32")]
         promote_scalars!(impl $imp<i32> for $res, $method, i8, i16, isize);
         #[cfg(target_pointer_width = "64")]
         promote_scalars!(impl $imp<i32> for $res, $method, i8, i16);
+    }
+}
+
+macro_rules! promote_signed_scalars_to_i64 {
+    (impl $imp:ident for $res:ty, $method:ident) => {
+        #[cfg(target_pointer_width = "64")]
+        promote_scalars!(impl $imp<i64> for $res, $method, isize);
     }
 }
 
@@ -273,12 +287,14 @@ macro_rules! forward_all_scalar_binop_to_val_val_commutative {
 macro_rules! promote_unsigned_scalars {
     (impl $imp:ident for $res:ty, $method:ident) => {
         promote_unsigned_scalars_to_u32!(impl $imp for $res, $method);
+        promote_unsigned_scalars_to_u64!(impl $imp for $res, $method);
     }
 }
 
 macro_rules! promote_signed_scalars {
     (impl $imp:ident for $res:ty, $method:ident) => {
         promote_signed_scalars_to_i32!(impl $imp for $res, $method);
+        promote_signed_scalars_to_i64!(impl $imp for $res, $method);
     }
 }
 

--- a/bigint/src/macros.rs
+++ b/bigint/src/macros.rs
@@ -105,6 +105,85 @@ macro_rules! forward_ref_ref_binop_commutative {
     }
 }
 
+macro_rules! forward_scalar_val_val_binop {
+    (impl $imp:ident<$scalar:ty> for $res:ty, $method: ident) => {
+        impl $imp<$res> for $scalar {
+            type Output = $res;
+
+            #[inline]
+            fn $method(self, other: $res) -> $res {
+                $imp::$method(other, self)
+            }
+        }
+    }
+}
+
+macro_rules! forward_scalar_val_ref_binop {
+    (impl $imp:ident<$scalar:ty> for $res:ty, $method:ident) => {
+        impl<'a> $imp<&'a $scalar> for $res {
+            type Output = $res;
+
+            #[inline]
+            fn $method(self, other: &$scalar) -> $res {
+                $imp::$method(self, *other)
+            }
+        }
+
+        impl<'a> $imp<$res> for &'a $scalar {
+            type Output = $res;
+
+            #[inline]
+            fn $method(self, other: $res) -> $res {
+                $imp::$method(other, *self)
+            }
+        }
+    }
+}
+
+macro_rules! forward_scalar_ref_val_binop {
+    (impl $imp:ident<$scalar:ty> for $res:ty, $method:ident) => {
+        impl<'a> $imp<$scalar> for &'a $res {
+            type Output = $res;
+
+            #[inline]
+            fn $method(self, other: $scalar) -> $res {
+                $imp::$method(self.clone(), other)
+            }
+        }
+
+        impl<'a> $imp<&'a $res> for $scalar {
+            type Output = $res;
+
+            #[inline]
+            fn $method(self, other: &$res) -> $res {
+                $imp::$method(other.clone(), self)
+            }
+        }
+    }
+}
+
+macro_rules! forward_scalar_ref_ref_binop {
+    (impl $imp:ident<$scalar:ty> for $res:ty, $method:ident) => {
+        impl<'a, 'b> $imp<&'b $scalar> for &'a $res {
+            type Output = $res;
+
+            #[inline]
+            fn $method(self, other: &$scalar) -> $res {
+                $imp::$method(self.clone(), *other)
+            }
+        }
+
+        impl<'a, 'b> $imp<&'a $res> for &'b $scalar {
+            type Output = $res;
+
+            #[inline]
+            fn $method(self, other: &$res) -> $res {
+                $imp::$method(other.clone(), *self)
+            }
+        }
+    }
+}
+
 // Forward everything to ref-ref, when reusing storage is not helpful
 macro_rules! forward_all_binop_to_ref_ref {
     (impl $imp:ident for $res:ty, $method:ident) => {
@@ -130,4 +209,13 @@ macro_rules! forward_all_binop_to_val_ref_commutative {
         forward_ref_val_binop_commutative!(impl $imp for $res, $method);
         forward_ref_ref_binop_commutative!(impl $imp for $res, $method);
     };
+}
+
+macro_rules! forward_all_scalar_binop_to_val_val {
+    (impl $imp:ident<$scalar:ty> for $res:ty, $method:ident) => {
+        forward_scalar_val_val_binop!(impl $imp<$scalar> for $res, $method);
+        forward_scalar_val_ref_binop!(impl $imp<$scalar> for $res, $method);
+        forward_scalar_ref_val_binop!(impl $imp<$scalar> for $res, $method);
+        forward_scalar_ref_ref_binop!(impl $imp<$scalar> for $res, $method);
+    }
 }

--- a/bigint/src/macros.rs
+++ b/bigint/src/macros.rs
@@ -105,7 +105,7 @@ macro_rules! forward_ref_ref_binop_commutative {
     }
 }
 
-macro_rules! forward_scalar_val_val_binop {
+macro_rules! forward_scalar_val_val_binop_commutative {
     (impl $imp:ident<$scalar:ty> for $res:ty, $method: ident) => {
         impl $imp<$res> for $scalar {
             type Output = $res;
@@ -118,7 +118,7 @@ macro_rules! forward_scalar_val_val_binop {
     }
 }
 
-macro_rules! forward_scalar_val_ref_binop {
+macro_rules! forward_scalar_val_ref_binop_commutative {
     (impl $imp:ident<$scalar:ty> for $res:ty, $method:ident) => {
         impl<'a> $imp<&'a $scalar> for $res {
             type Output = $res;
@@ -140,7 +140,7 @@ macro_rules! forward_scalar_val_ref_binop {
     }
 }
 
-macro_rules! forward_scalar_ref_val_binop {
+macro_rules! forward_scalar_ref_val_binop_commutative {
     (impl $imp:ident<$scalar:ty> for $res:ty, $method:ident) => {
         impl<'a> $imp<$scalar> for &'a $res {
             type Output = $res;
@@ -162,7 +162,7 @@ macro_rules! forward_scalar_ref_val_binop {
     }
 }
 
-macro_rules! forward_scalar_ref_ref_binop {
+macro_rules! forward_scalar_ref_ref_binop_commutative {
     (impl $imp:ident<$scalar:ty> for $res:ty, $method:ident) => {
         impl<'a, 'b> $imp<&'b $scalar> for &'a $res {
             type Output = $res;
@@ -211,11 +211,11 @@ macro_rules! forward_all_binop_to_val_ref_commutative {
     };
 }
 
-macro_rules! forward_all_scalar_binop_to_val_val {
+macro_rules! forward_all_scalar_binop_to_val_val_commutative {
     (impl $imp:ident<$scalar:ty> for $res:ty, $method:ident) => {
-        forward_scalar_val_val_binop!(impl $imp<$scalar> for $res, $method);
-        forward_scalar_val_ref_binop!(impl $imp<$scalar> for $res, $method);
-        forward_scalar_ref_val_binop!(impl $imp<$scalar> for $res, $method);
-        forward_scalar_ref_ref_binop!(impl $imp<$scalar> for $res, $method);
+        forward_scalar_val_val_binop_commutative!(impl $imp<$scalar> for $res, $method);
+        forward_scalar_val_ref_binop_commutative!(impl $imp<$scalar> for $res, $method);
+        forward_scalar_ref_val_binop_commutative!(impl $imp<$scalar> for $res, $method);
+        forward_scalar_ref_ref_binop_commutative!(impl $imp<$scalar> for $res, $method);
     }
 }

--- a/bigint/src/tests/bigint.rs
+++ b/bigint/src/tests/bigint.rs
@@ -1,4 +1,4 @@
-use {BigDigit, BigUint, big_digit};
+use {BigDigit, DoubleBigDigit, BigUint, big_digit};
 use {Sign, BigInt, RandBigInt, ToBigInt};
 use Sign::{Minus, NoSign, Plus};
 
@@ -532,6 +532,16 @@ const SUM_TRIPLES: &'static [(&'static [BigDigit],
                                      (&[1, 1, 1], &[N1, N1], &[0, 1, 2]),
                                      (&[2, 2, 1], &[N1, N2], &[1, 1, 2])];
 
+fn get_scalar(vec: &[BigDigit]) -> BigDigit {
+    vec.get(0).map_or(0, BigDigit::clone)
+}
+
+fn get_scalar_double(vec: &[BigDigit]) -> DoubleBigDigit {
+    let lo = vec.get(0).map_or(0, BigDigit::clone);
+    let hi = vec.get(1).map_or(0, BigDigit::clone);
+    big_digit::to_doublebigdigit(hi, lo)
+}
+
 #[test]
 fn test_add() {
     for elm in SUM_TRIPLES.iter() {
@@ -561,8 +571,8 @@ fn test_scalar_add() {
         let c = BigInt::from_slice(Plus, c_vec);
         let (na, nb, nc) = (-&a, -&b, -&c);
 
-        if a_vec.len() == 1 {
-            let a = a_vec[0];
+        if a_vec.len() <= 1 {
+            let a = get_scalar(a_vec);
             assert_op!(a + b == c);
             assert_op!(b + a == c);
             assert_op!(a + nc == nb);
@@ -577,8 +587,24 @@ fn test_scalar_add() {
             }
         }
 
-        if b_vec.len() == 1 {
-            let b = b_vec[0];
+        if a_vec.len() <= 2 {
+            let a = get_scalar_double(a_vec);
+            assert_op!(a + b == c);
+            assert_op!(b + a == c);
+            assert_op!(a + nc == nb);
+            assert_op!(nc + a == nb);
+
+            if a <= i64::max_value() as u64 {
+                let na = -(a as i64);
+                assert_op!(na + nb == nc);
+                assert_op!(nb + na == nc);
+                assert_op!(na + c == b);
+                assert_op!(c + na == b);
+            }
+        }
+
+        if b_vec.len() <= 1 {
+            let b = get_scalar(b_vec);
             assert_op!(a + b == c);
             assert_op!(b + a == c);
             assert_op!(b + nc == na);
@@ -586,6 +612,22 @@ fn test_scalar_add() {
 
             if b <= i32::max_value() as u32 {
                 let nb = -(b as i32);
+                assert_op!(na + nb == nc);
+                assert_op!(nb + na == nc);
+                assert_op!(nb + c == a);
+                assert_op!(c + nb == a);
+            }
+        }
+
+        if b_vec.len() <= 2 {
+            let b = get_scalar_double(b_vec);
+            assert_op!(a + b == c);
+            assert_op!(b + a == c);
+            assert_op!(b + nc == na);
+            assert_op!(nc + b == na);
+
+            if b <= i64::max_value() as u64 {
+                let nb = -(b as i64);
                 assert_op!(na + nb == nc);
                 assert_op!(nb + na == nc);
                 assert_op!(nb + c == a);

--- a/bigint/src/tests/bigint.rs
+++ b/bigint/src/tests/bigint.rs
@@ -556,9 +556,10 @@ fn test_add() {
 fn test_scalar_add() {
     for elm in SUM_TRIPLES.iter() {
         let (a_vec, b_vec, c_vec) = *elm;
+        let a = BigInt::from_slice(Plus, a_vec);
         let b = BigInt::from_slice(Plus, b_vec);
         let c = BigInt::from_slice(Plus, c_vec);
-        let (nb, nc) = (-&b, -&c);
+        let (na, nb, nc) = (-&a, -&b, -&c);
 
         if a_vec.len() == 1 {
             let a = a_vec[0];
@@ -566,6 +567,14 @@ fn test_scalar_add() {
             assert_op!(b + a == c);
             assert_op!(a + nc == nb);
             assert_op!(nc + a == nb);
+        }
+
+        if b_vec.len() == 1 {
+            let b = b_vec[0];
+            assert_op!(a + b == c);
+            assert_op!(b + a == c);
+            assert_op!(b + nc == na);
+            assert_op!(nc + b == na);
         }
     }
 }
@@ -587,6 +596,41 @@ fn test_sub() {
         assert_op!(a - nb == c);
         assert_op!(nc - na == nb);
         assert_op!(a - a == Zero::zero());
+    }
+}
+
+#[test]
+fn test_scalar_sub() {
+    for elm in SUM_TRIPLES.iter() {
+        let (a_vec, b_vec, c_vec) = *elm;
+        let a = BigInt::from_slice(Plus, a_vec);
+        let b = BigInt::from_slice(Plus, b_vec);
+        let c = BigInt::from_slice(Plus, c_vec);
+        let (na, nb, nc) = (-&a, -&b, -&c);
+
+        if a_vec.len() == 1 {
+            let a = a_vec[0];
+            assert_op!(c - a == b);
+            assert_op!(a - c == nb);
+            assert_op!(a - nb == c);
+            assert_op!(nb - a == nc);
+        }
+
+        if b_vec.len() == 1 {
+            let b = b_vec[0];
+            assert_op!(c - b == a);
+            assert_op!(b - c == na);
+            assert_op!(b - na == c);
+            assert_op!(na - b == nc);
+        }
+
+        if c_vec.len() == 1 {
+            let c = c_vec[0];
+            assert_op!(c - a == b);
+            assert_op!(a - c == nb);
+            assert_op!(c - b == a);
+            assert_op!(b - c == na);
+        }
     }
 }
 

--- a/bigint/src/tests/bigint.rs
+++ b/bigint/src/tests/bigint.rs
@@ -567,6 +567,14 @@ fn test_scalar_add() {
             assert_op!(b + a == c);
             assert_op!(a + nc == nb);
             assert_op!(nc + a == nb);
+
+            if a <= i32::max_value() as u32 {
+                let na = -(a as i32);
+                assert_op!(na + nb == nc);
+                assert_op!(nb + na == nc);
+                assert_op!(na + c == b);
+                assert_op!(c + na == b);
+            }
         }
 
         if b_vec.len() == 1 {
@@ -575,6 +583,14 @@ fn test_scalar_add() {
             assert_op!(b + a == c);
             assert_op!(b + nc == na);
             assert_op!(nc + b == na);
+
+            if b <= i32::max_value() as u32 {
+                let nb = -(b as i32);
+                assert_op!(na + nb == nc);
+                assert_op!(nb + na == nc);
+                assert_op!(nb + c == a);
+                assert_op!(c + nb == a);
+            }
         }
     }
 }
@@ -614,6 +630,14 @@ fn test_scalar_sub() {
             assert_op!(a - c == nb);
             assert_op!(a - nb == c);
             assert_op!(nb - a == nc);
+
+            if a <= i32::max_value() as u32 {
+                let na = -(a as i32);
+                assert_op!(nc - na == nb);
+                assert_op!(na - nc == b);
+                assert_op!(na - b == nc);
+                assert_op!(b - na == c);
+            }
         }
 
         if b_vec.len() == 1 {
@@ -622,6 +646,14 @@ fn test_scalar_sub() {
             assert_op!(b - c == na);
             assert_op!(b - na == c);
             assert_op!(na - b == nc);
+
+            if b <= i32::max_value() as u32 {
+                let nb = -(b as i32);
+                assert_op!(nc - nb == na);
+                assert_op!(nb - nc == a);
+                assert_op!(nb - a == nc);
+                assert_op!(a - nb == c);
+            }
         }
 
         if c_vec.len() == 1 {
@@ -630,6 +662,14 @@ fn test_scalar_sub() {
             assert_op!(a - c == nb);
             assert_op!(c - b == a);
             assert_op!(b - c == na);
+
+            if c <= i32::max_value() as u32 {
+                let nc = -(c as i32);
+                assert_op!(nc - na == nb);
+                assert_op!(na - nc == b);
+                assert_op!(nc - nb == na);
+                assert_op!(nb - nc == a);
+            }
         }
     }
 }
@@ -665,6 +705,7 @@ static DIV_REM_QUADRUPLES: &'static [(&'static [BigDigit],
            &'static [BigDigit],
            &'static [BigDigit],
            &'static [BigDigit])] = &[(&[1], &[2], &[], &[1]),
+                                     (&[3], &[2], &[1], &[1]),
                                      (&[1, 1], &[2], &[M / 2 + 1], &[1]),
                                      (&[1, 1, 1], &[2], &[M / 2 + 1, M / 2 + 1], &[1]),
                                      (&[0, 1], &[N1], &[1], &[1]),
@@ -714,6 +755,14 @@ fn test_scalar_mul() {
             assert_op!(a * b == c);
             assert_op!(nb * a == nc);
             assert_op!(a * nb == nc);
+
+            if a <= i32::max_value() as u32 {
+                let na = -(a as i32);
+                assert_op!(nb * na == c);
+                assert_op!(na * nb == c);
+                assert_op!(b * na == nc);
+                assert_op!(na * b == nc);
+            }
         }
 
         if b_vec.len() == 1 {
@@ -722,6 +771,14 @@ fn test_scalar_mul() {
             assert_op!(b * a == c);
             assert_op!(na * b == nc);
             assert_op!(b * na == nc);
+
+            if b <= i32::max_value() as u32 {
+                let nb = -(b as i32);
+                assert_op!(na * nb == c);
+                assert_op!(nb * na == c);
+                assert_op!(a * nb == nc);
+                assert_op!(nb * a == nc);
+            }
         }
     }
 }
@@ -847,6 +904,12 @@ fn test_scalar_div_rem() {
         let (a, b, ans_q, ans_r) = (a.clone(), b.clone(), ans_q.clone(), ans_r.clone());
         assert_op!(a / b == ans_q);
         assert_op!(a % b == ans_r);
+
+        if b <= i32::max_value() as u32 {
+            let nb = -(b as i32);
+            assert_op!(a / nb == -ans_q.clone());
+            assert_op!(a % nb == ans_r);
+        }
     }
 
     fn check(a: &BigInt, b: BigDigit, q: &BigInt, r: &BigInt) {

--- a/bigint/src/tests/bigint.rs
+++ b/bigint/src/tests/bigint.rs
@@ -638,6 +638,31 @@ fn test_mul() {
 }
 
 #[test]
+fn test_scalar_mul() {
+    for elm in MUL_TRIPLES.iter() {
+        let (a_vec, b_vec, c_vec) = *elm;
+        let c = BigInt::from_slice(Plus, c_vec);
+        let nc = BigInt::from_slice(Minus, c_vec);
+
+        if a_vec.len() == 1 {
+            let b = BigInt::from_slice(Plus, b_vec);
+            let nb = BigInt::from_slice(Minus, b_vec);
+            let a = a_vec[0];
+            assert!(b * a == c);
+            assert!(nb * a == nc);
+        }
+
+        if b_vec.len() == 1 {
+            let a = BigInt::from_slice(Plus, a_vec);
+            let na = BigInt::from_slice(Minus, a_vec);
+            let b = b_vec[0];
+            assert!(a * b == c);
+            assert!(na * b == nc);
+        }
+    }
+}
+
+#[test]
 fn test_div_mod_floor() {
     fn check_sub(a: &BigInt, b: &BigInt, ans_d: &BigInt, ans_m: &BigInt) {
         let (d, m) = a.div_mod_floor(b);

--- a/bigint/src/tests/bigint.rs
+++ b/bigint/src/tests/bigint.rs
@@ -833,6 +833,59 @@ fn test_div_rem() {
 }
 
 #[test]
+fn test_scalar_div_rem() {
+    fn check_sub(a: &BigInt, b: BigDigit, ans_q: &BigInt, ans_r: &BigInt) {
+        let (q, r) = (a / b, a % b);
+        if !r.is_zero() {
+            assert_eq!(r.sign, a.sign);
+        }
+        assert!(r.abs() <= From::from(b));
+        assert!(*a == b * &q + &r);
+        assert!(q == *ans_q);
+        assert!(r == *ans_r);
+
+        let (a, b, ans_q, ans_r) = (a.clone(), b.clone(), ans_q.clone(), ans_r.clone());
+        assert_op!(a / b == ans_q);
+        assert_op!(a % b == ans_r);
+    }
+
+    fn check(a: &BigInt, b: BigDigit, q: &BigInt, r: &BigInt) {
+        check_sub(a, b, q, r);
+        check_sub(&a.neg(), b, &q.neg(), &r.neg());
+    }
+
+    for elm in MUL_TRIPLES.iter() {
+        let (a_vec, b_vec, c_vec) = *elm;
+        let a = BigInt::from_slice(Plus, a_vec);
+        let b = BigInt::from_slice(Plus, b_vec);
+        let c = BigInt::from_slice(Plus, c_vec);
+
+        if a_vec.len() == 1 && a_vec[0] != 0 {
+            let a = a_vec[0];
+            check(&c, a, &b, &Zero::zero());
+        }
+
+        if b_vec.len() == 1 && b_vec[0] != 0 {
+            let b = b_vec[0];
+            check(&c, b, &a, &Zero::zero());
+        }
+    }
+
+    for elm in DIV_REM_QUADRUPLES.iter() {
+        let (a_vec, b_vec, c_vec, d_vec) = *elm;
+        let a = BigInt::from_slice(Plus, a_vec);
+        let c = BigInt::from_slice(Plus, c_vec);
+        let d = BigInt::from_slice(Plus, d_vec);
+
+        if b_vec.len() == 1 && b_vec[0] != 0 {
+            let b = b_vec[0];
+            check(&a, b, &c, &d);
+        }
+    }
+
+}
+
+#[test]
 fn test_checked_add() {
     for elm in SUM_TRIPLES.iter() {
         let (a_vec, b_vec, c_vec) = *elm;

--- a/bigint/src/tests/bigint.rs
+++ b/bigint/src/tests/bigint.rs
@@ -553,6 +553,24 @@ fn test_add() {
 }
 
 #[test]
+fn test_scalar_add() {
+    for elm in SUM_TRIPLES.iter() {
+        let (a_vec, b_vec, c_vec) = *elm;
+        let b = BigInt::from_slice(Plus, b_vec);
+        let c = BigInt::from_slice(Plus, c_vec);
+        let (nb, nc) = (-&b, -&c);
+
+        if a_vec.len() == 1 {
+            let a = a_vec[0];
+            assert_op!(a + b == c);
+            assert_op!(b + a == c);
+            assert_op!(a + nc == nb);
+            assert_op!(nc + a == nb);
+        }
+    }
+}
+
+#[test]
 fn test_sub() {
     for elm in SUM_TRIPLES.iter() {
         let (a_vec, b_vec, c_vec) = *elm;

--- a/bigint/src/tests/bigint.rs
+++ b/bigint/src/tests/bigint.rs
@@ -703,23 +703,25 @@ fn test_mul() {
 fn test_scalar_mul() {
     for elm in MUL_TRIPLES.iter() {
         let (a_vec, b_vec, c_vec) = *elm;
+        let a = BigInt::from_slice(Plus, a_vec);
+        let b = BigInt::from_slice(Plus, b_vec);
         let c = BigInt::from_slice(Plus, c_vec);
-        let nc = BigInt::from_slice(Minus, c_vec);
+        let (na, nb, nc) = (-&a, -&b, -&c);
 
         if a_vec.len() == 1 {
-            let b = BigInt::from_slice(Plus, b_vec);
-            let nb = BigInt::from_slice(Minus, b_vec);
             let a = a_vec[0];
-            assert!(b * a == c);
-            assert!(nb * a == nc);
+            assert_op!(b * a == c);
+            assert_op!(a * b == c);
+            assert_op!(nb * a == nc);
+            assert_op!(a * nb == nc);
         }
 
         if b_vec.len() == 1 {
-            let a = BigInt::from_slice(Plus, a_vec);
-            let na = BigInt::from_slice(Minus, a_vec);
             let b = b_vec[0];
-            assert!(a * b == c);
-            assert!(na * b == nc);
+            assert_op!(a * b == c);
+            assert_op!(b * a == c);
+            assert_op!(na * b == nc);
+            assert_op!(b * na == nc);
         }
     }
 }

--- a/bigint/src/tests/biguint.rs
+++ b/bigint/src/tests/biguint.rs
@@ -692,22 +692,22 @@ fn test_add() {
 
 #[test]
 fn test_scalar_add() {
-  for elm in SUM_TRIPLES.iter() {
-      let (a_vec, b_vec, c_vec) = *elm;
-      let c = BigUint::from_slice(c_vec);
+    for elm in SUM_TRIPLES.iter() {
+        let (a_vec, b_vec, c_vec) = *elm;
+        let a = BigUint::from_slice(a_vec);
+        let b = BigUint::from_slice(b_vec);
+        let c = BigUint::from_slice(c_vec);
 
-      if a_vec.len() == 1 {
-          let a = a_vec[0];
-          let b = BigUint::from_slice(b_vec);
-          assert_op!(a + b == c);
-          assert_op!(b + a == c);
-      }
+        if a_vec.len() == 1 {
+            let a = a_vec[0];
+            assert_op!(a + b == c);
+            assert_op!(b + a == c);
+        }
 
-      if b_vec.len() == 1 {
-          let a = BigUint::from_slice(a_vec);
-          let b = b_vec[0];
-          assert_op!(a + b == c);
-          assert_op!(b + a == c);
+        if b_vec.len() == 1 {
+            let b = b_vec[0];
+            assert_op!(a + b == c);
+            assert_op!(b + a == c);
         }
     }
 }
@@ -729,24 +729,21 @@ fn test_sub() {
 fn test_scalar_sub() {
     for elm in SUM_TRIPLES.iter() {
         let (a_vec, b_vec, c_vec) = *elm;
+        let a = BigUint::from_slice(a_vec);
+        let b = BigUint::from_slice(b_vec);
+        let c = BigUint::from_slice(c_vec);
 
         if a_vec.len() == 1 {
             let a = a_vec[0];
-            let b = BigUint::from_slice(b_vec);
-            let c = BigUint::from_slice(c_vec);
             assert_op!(c - a == b);
         }
 
         if b_vec.len() == 1 {
-            let a = BigUint::from_slice(a_vec);
             let b = b_vec[0];
-            let c = BigUint::from_slice(c_vec);
             assert_op!(c - b == a);
         }
 
         if c_vec.len() == 1 {
-            let a = BigUint::from_slice(a_vec);
-            let b = BigUint::from_slice(b_vec);
             let c = c_vec[0];
             assert_op!(c - a == b);
             assert_op!(c - b == a);
@@ -792,6 +789,7 @@ const DIV_REM_QUADRUPLES: &'static [(&'static [BigDigit],
            &'static [BigDigit],
            &'static [BigDigit],
            &'static [BigDigit])] = &[(&[1], &[2], &[], &[1]),
+                                     (&[3], &[2], &[1], &[1]),
                                      (&[1, 1], &[2], &[M / 2 + 1], &[1]),
                                      (&[1, 1, 1], &[2], &[M / 2 + 1, M / 2 + 1], &[1]),
                                      (&[0, 1], &[N1], &[1], &[1]),
@@ -825,17 +823,17 @@ fn test_mul() {
 fn test_scalar_mul() {
     for elm in MUL_TRIPLES.iter() {
         let (a_vec, b_vec, c_vec) = *elm;
+        let a = BigUint::from_slice(a_vec);
+        let b = BigUint::from_slice(b_vec);
         let c = BigUint::from_slice(c_vec);
 
         if a_vec.len() == 1 {
-            let b = BigUint::from_slice(b_vec);
             let a = a_vec[0];
             assert_op!(a * b == c);
             assert_op!(b * a == c);
         }
 
         if b_vec.len() == 1 {
-            let a = BigUint::from_slice(a_vec);
             let b = b_vec[0];
             assert_op!(a * b == c);
             assert_op!(b * a == c);
@@ -882,33 +880,52 @@ fn test_div_rem() {
 fn test_scalar_div_rem() {
     for elm in MUL_TRIPLES.iter() {
         let (a_vec, b_vec, c_vec) = *elm;
+        let a = BigUint::from_slice(a_vec);
+        let b = BigUint::from_slice(b_vec);
         let c = BigUint::from_slice(c_vec);
 
         if a_vec.len() == 1 && a_vec[0] != 0 {
             let a = a_vec[0];
-            let b = BigUint::from_slice(b_vec);
-            assert!(c.clone() / a == b);
-            assert!(c.clone() % a == Zero::zero());
+            assert_op!(c / a == b);
+            assert_op!(c % a == Zero::zero());
         }
 
         if b_vec.len() == 1 && b_vec[0] != 0 {
-            let a = BigUint::from_slice(a_vec);
             let b = b_vec[0];
-            assert!(c.clone() / b == a);
-            assert!(c.clone() % b == Zero::zero());
+            assert_op!(c / b == a);
+            assert_op!(c % b == Zero::zero());
+        }
+
+        if c_vec.len() == 1 {
+            let c = c_vec[0];
+            if !a.is_zero() {
+                assert_op!(c / a == b);
+                assert_op!(c % a == Zero::zero());
+            }
+            if !b.is_zero() {
+                assert_op!(c / b == a);
+                assert_op!(c % b == Zero::zero());
+            }
         }
     }
 
     for elm in DIV_REM_QUADRUPLES.iter() {
         let (a_vec, b_vec, c_vec, d_vec) = *elm;
         let a = BigUint::from_slice(a_vec);
+        let b = BigUint::from_slice(b_vec);
         let c = BigUint::from_slice(c_vec);
+        let d = BigUint::from_slice(d_vec);
 
         if b_vec.len() == 1 && b_vec[0] != 0 {
             let b = b_vec[0];
-            let d = d_vec[0];
-            assert!(a.clone() / b == c);
-            assert!(a.clone() % b == d);
+            assert_op!(a / b == c);
+            assert_op!(a % b == d);
+        }
+
+        if a_vec.len() == 1 && !b.is_zero() {
+            let a = a_vec[0];
+            assert_op!(a / b == c);
+            assert_op!(a % b == d);
         }
     }
 }

--- a/bigint/src/tests/biguint.rs
+++ b/bigint/src/tests/biguint.rs
@@ -771,6 +771,26 @@ fn test_mul() {
 }
 
 #[test]
+fn test_scalar_mul() {
+    for elm in MUL_TRIPLES.iter() {
+        let (a_vec, b_vec, c_vec) = *elm;
+        let c = BigUint::from_slice(c_vec);
+
+        if a_vec.len() == 1 {
+            let b = BigUint::from_slice(b_vec);
+            let a = a_vec[0];
+            assert!(b * a == c);
+        }
+
+        if b_vec.len() == 1 {
+            let a = BigUint::from_slice(a_vec);
+            let b = b_vec[0];
+            assert!(a * b == c);
+        }
+    }
+}
+
+#[test]
 fn test_div_rem() {
     for elm in MUL_TRIPLES.iter() {
         let (a_vec, b_vec, c_vec) = *elm;

--- a/bigint/src/tests/biguint.rs
+++ b/bigint/src/tests/biguint.rs
@@ -822,13 +822,15 @@ fn test_scalar_mul() {
         if a_vec.len() == 1 {
             let b = BigUint::from_slice(b_vec);
             let a = a_vec[0];
-            assert!(b * a == c);
+            assert_op!(a * b == c);
+            assert_op!(b * a == c);
         }
 
         if b_vec.len() == 1 {
             let a = BigUint::from_slice(a_vec);
             let b = b_vec[0];
-            assert!(a * b == c);
+            assert_op!(a * b == c);
+            assert_op!(b * a == c);
         }
     }
 }

--- a/bigint/src/tests/biguint.rs
+++ b/bigint/src/tests/biguint.rs
@@ -699,13 +699,15 @@ fn test_scalar_add() {
       if a_vec.len() == 1 {
           let a = a_vec[0];
           let b = BigUint::from_slice(b_vec);
-          assert!(b + a == c);
+          assert_op!(a + b == c);
+          assert_op!(b + a == c);
       }
 
       if b_vec.len() == 1 {
           let a = BigUint::from_slice(a_vec);
           let b = b_vec[0];
-          assert!(a + b == c);
+          assert_op!(a + b == c);
+          assert_op!(b + a == c);
         }
     }
 }

--- a/bigint/src/tests/biguint.rs
+++ b/bigint/src/tests/biguint.rs
@@ -724,6 +724,27 @@ fn test_sub() {
 }
 
 #[test]
+fn test_scalar_sub() {
+    for elm in SUM_TRIPLES.iter() {
+        let (a_vec, b_vec, c_vec) = *elm;
+
+        if a_vec.len() == 1 {
+            let a = a_vec[0];
+            let b = BigUint::from_slice(b_vec);
+            let c = BigUint::from_slice(c_vec);
+            assert!(c - a == b);
+        }
+
+        if b_vec.len() == 1 {
+            let a = BigUint::from_slice(a_vec);
+            let b = b_vec[0];
+            let c = BigUint::from_slice(c_vec);
+            assert!(c - b == a);
+        }
+    }
+}
+
+#[test]
 #[should_panic]
 fn test_sub_fail_on_underflow() {
     let (a, b): (BigUint, BigUint) = (Zero::zero(), One::one());

--- a/bigint/src/tests/biguint.rs
+++ b/bigint/src/tests/biguint.rs
@@ -867,6 +867,41 @@ fn test_div_rem() {
 }
 
 #[test]
+fn test_scalar_div_rem() {
+    for elm in MUL_TRIPLES.iter() {
+        let (a_vec, b_vec, c_vec) = *elm;
+        let c = BigUint::from_slice(c_vec);
+
+        if a_vec.len() == 1 && a_vec[0] != 0 {
+            let a = a_vec[0];
+            let b = BigUint::from_slice(b_vec);
+            assert!(c.clone() / a == b);
+            assert!(c.clone() % a == Zero::zero());
+        }
+
+        if b_vec.len() == 1 && b_vec[0] != 0 {
+            let a = BigUint::from_slice(a_vec);
+            let b = b_vec[0];
+            assert!(c.clone() / b == a);
+            assert!(c.clone() % b == Zero::zero());
+        }
+    }
+
+    for elm in DIV_REM_QUADRUPLES.iter() {
+        let (a_vec, b_vec, c_vec, d_vec) = *elm;
+        let a = BigUint::from_slice(a_vec);
+        let c = BigUint::from_slice(c_vec);
+
+        if b_vec.len() == 1 && b_vec[0] != 0 {
+            let b = b_vec[0];
+            let d = d_vec[0];
+            assert!(a.clone() / b == c);
+            assert!(a.clone() % b == d);
+        }
+    }
+}
+
+#[test]
 fn test_checked_add() {
     for elm in SUM_TRIPLES.iter() {
         let (a_vec, b_vec, c_vec) = *elm;

--- a/bigint/src/tests/biguint.rs
+++ b/bigint/src/tests/biguint.rs
@@ -1,5 +1,5 @@
 use integer::Integer;
-use {BigDigit, BigUint, ToBigUint, big_digit};
+use {BigDigit, DoubleBigDigit, BigUint, ToBigUint, big_digit};
 use {BigInt, RandBigInt, ToBigInt};
 use Sign::Plus;
 
@@ -677,6 +677,16 @@ const SUM_TRIPLES: &'static [(&'static [BigDigit],
                                      (&[1, 1, 1], &[N1, N1], &[0, 1, 2]),
                                      (&[2, 2, 1], &[N1, N2], &[1, 1, 2])];
 
+fn get_scalar(vec: &[BigDigit]) -> BigDigit {
+    vec.get(0).map_or(0, BigDigit::clone)
+}
+
+fn get_scalar_double(vec: &[BigDigit]) -> DoubleBigDigit {
+    let lo = vec.get(0).map_or(0, BigDigit::clone);
+    let hi = vec.get(1).map_or(0, BigDigit::clone);
+    big_digit::to_doublebigdigit(hi, lo)
+}
+
 #[test]
 fn test_add() {
     for elm in SUM_TRIPLES.iter() {
@@ -698,14 +708,26 @@ fn test_scalar_add() {
         let b = BigUint::from_slice(b_vec);
         let c = BigUint::from_slice(c_vec);
 
-        if a_vec.len() == 1 {
-            let a = a_vec[0];
+        if a_vec.len() <= 1 {
+            let a = get_scalar(a_vec);
             assert_op!(a + b == c);
             assert_op!(b + a == c);
         }
 
-        if b_vec.len() == 1 {
-            let b = b_vec[0];
+        if a_vec.len() <= 2 {
+            let a = get_scalar_double(a_vec);
+            assert_op!(a + b == c);
+            assert_op!(b + a == c);
+        }
+
+        if b_vec.len() <= 1 {
+            let b = get_scalar(b_vec);
+            assert_op!(a + b == c);
+            assert_op!(b + a == c);
+        }
+
+        if b_vec.len() <= 2 {
+            let b = get_scalar_double(b_vec);
             assert_op!(a + b == c);
             assert_op!(b + a == c);
         }

--- a/bigint/src/tests/biguint.rs
+++ b/bigint/src/tests/biguint.rs
@@ -734,14 +734,22 @@ fn test_scalar_sub() {
             let a = a_vec[0];
             let b = BigUint::from_slice(b_vec);
             let c = BigUint::from_slice(c_vec);
-            assert!(c - a == b);
+            assert_op!(c - a == b);
         }
 
         if b_vec.len() == 1 {
             let a = BigUint::from_slice(a_vec);
             let b = b_vec[0];
             let c = BigUint::from_slice(c_vec);
-            assert!(c - b == a);
+            assert_op!(c - b == a);
+        }
+
+        if c_vec.len() == 1 {
+            let a = BigUint::from_slice(a_vec);
+            let b = BigUint::from_slice(b_vec);
+            let c = c_vec[0];
+            assert_op!(c - a == b);
+            assert_op!(c - b == a);
         }
     }
 }

--- a/bigint/src/tests/biguint.rs
+++ b/bigint/src/tests/biguint.rs
@@ -691,6 +691,26 @@ fn test_add() {
 }
 
 #[test]
+fn test_scalar_add() {
+  for elm in SUM_TRIPLES.iter() {
+      let (a_vec, b_vec, c_vec) = *elm;
+      let c = BigUint::from_slice(c_vec);
+
+      if a_vec.len() == 1 {
+          let a = a_vec[0];
+          let b = BigUint::from_slice(b_vec);
+          assert!(b + a == c);
+      }
+
+      if b_vec.len() == 1 {
+          let a = BigUint::from_slice(a_vec);
+          let b = b_vec[0];
+          assert!(a + b == c);
+        }
+    }
+}
+
+#[test]
 fn test_sub() {
     for elm in SUM_TRIPLES.iter() {
         let (a_vec, b_vec, c_vec) = *elm;


### PR DESCRIPTION
With my apologies for opening a new PR, and also for the 8 month delay, this continues the work started in #237 - the discussion there outlines the goals I was aiming for. I suppose this supersedes that PR and the other one can now be closed.

This PR adds support for Add, Sub, Mul, Div and Rem operations involving one BigInt/BigUint and one primitive integer, with operands in either order, and any combination of owned/borrowed arguments.

