### PR TITLE
Fix float NaN positive/negative assumptions

### DIFF
--- a/traits/src/float.rs
+++ b/traits/src/float.rs
@@ -330,14 +330,14 @@ pub trait Float
     /// use num_traits::Float;
     /// use std::f64;
     ///
-    /// let nan: f64 = f64::NAN;
+    /// let neg_nan: f64 = -f64::NAN;
     ///
     /// let f = 7.0;
     /// let g = -7.0;
     ///
     /// assert!(f.is_sign_positive());
     /// assert!(!g.is_sign_positive());
-    /// assert!(!nan.is_sign_negative());
+    /// assert!(!neg_nan.is_sign_positive());
     /// ```
     fn is_sign_positive(self) -> bool;
 
@@ -348,14 +348,14 @@ pub trait Float
     /// use num_traits::Float;
     /// use std::f64;
     ///
-    /// let neg_nan: f64 = -f64::NAN;
+    /// let nan: f64 = f64::NAN;
     ///
     /// let f = 7.0;
     /// let g = -7.0;
     ///
     /// assert!(!f.is_sign_negative());
     /// assert!(g.is_sign_negative());
-    /// assert!(!neg_nan.is_sign_positive());
+    /// assert!(!nan.is_sign_negative());
     /// ```
     fn is_sign_negative(self) -> bool;
 

--- a/traits/src/float.rs
+++ b/traits/src/float.rs
@@ -324,7 +324,7 @@ pub trait Float
     fn signum(self) -> Self;
 
     /// Returns `true` if `self` is positive, including `+0.0`,
-    /// `Float::infinity()`, and `f64::NAN` with newer versions of Rust.
+    /// `Float::infinity()`, and with newer versions of Rust `f64::NAN`.
     ///
     /// ```
     /// use num_traits::Float;
@@ -342,7 +342,7 @@ pub trait Float
     fn is_sign_positive(self) -> bool;
 
     /// Returns `true` if `self` is negative, including `-0.0`,
-    /// `Float::neg_infinity()`, and `-f64::NAN` with newer versions of Rust.
+    /// `Float::neg_infinity()`, and with newer versions of Rust `-f64::NAN`.
     ///
     /// ```
     /// use num_traits::Float;

--- a/traits/src/float.rs
+++ b/traits/src/float.rs
@@ -323,8 +323,8 @@ pub trait Float
     /// ```
     fn signum(self) -> Self;
 
-    /// Returns `true` if `self` is positive, including `+0.0` and
-    /// `Float::infinity()`.
+    /// Returns `true` if `self` is positive, including `+0.0`,
+    /// `Float::infinity()`, and `f64::NAN` with newer versions of Rust.
     ///
     /// ```
     /// use num_traits::Float;
@@ -337,27 +337,25 @@ pub trait Float
     ///
     /// assert!(f.is_sign_positive());
     /// assert!(!g.is_sign_positive());
-    /// // Requires both tests to determine if is `NaN`
-    /// assert!(!nan.is_sign_positive() && !nan.is_sign_negative());
+    /// assert!(!nan.is_sign_negative());
     /// ```
     fn is_sign_positive(self) -> bool;
 
-    /// Returns `true` if `self` is negative, including `-0.0` and
-    /// `Float::neg_infinity()`.
+    /// Returns `true` if `self` is negative, including `-0.0`,
+    /// `Float::neg_infinity()`, and `-f64::NAN` with newer versions of Rust.
     ///
     /// ```
     /// use num_traits::Float;
     /// use std::f64;
     ///
-    /// let nan = f64::NAN;
+    /// let neg_nan: f64 = -f64::NAN;
     ///
     /// let f = 7.0;
     /// let g = -7.0;
     ///
     /// assert!(!f.is_sign_negative());
     /// assert!(g.is_sign_negative());
-    /// // Requires both tests to determine if is `NaN`.
-    /// assert!(!nan.is_sign_positive() && !nan.is_sign_negative());
+    /// assert!(!neg_nan.is_sign_positive());
     /// ```
     fn is_sign_negative(self) -> bool;
 


### PR DESCRIPTION
These are the minimal assumptions to make about `NaN`. Fixes part of #312 (but not the `next` branch).