### PR TITLE
Feature/complex from str

### DIFF
--- a/complex/src/lib.rs
+++ b/complex/src/lib.rs
@@ -748,7 +748,7 @@ impl<T> FromStr for Complex<T> where
     type Err = ParseComplexError<T::Err>;
 
     /// Parses `a +/- bi`; `ai +/- b`; `a`; or `bi` where `a` and `b` are of type `T`
-    fn from_str(s: &str) -> Result<Complex<T>, ParseComplexError<T::Err>>
+    fn from_str(s: &str) -> Result<Self, Self::Err>
     {
         let imag = match s.rfind('j') {
             None => 'i',

--- a/complex/src/lib.rs
+++ b/complex/src/lib.rs
@@ -773,7 +773,7 @@ impl<T> FromStr for Complex<T> where
                         // if `a` is imaginary, let `b` be real (and vice versa)
                         match a.rfind('i') {
                             None => "0i".to_string(),
-                            Some(u) => "0".to_string()
+                            _ => "0".to_string()
                         }
                     }
                     Some(s) => {
@@ -790,7 +790,7 @@ impl<T> FromStr for Complex<T> where
                 try!(T::from_str(&a)
                     .map_err(|_| ParseComplexError { kind: ComplexErrorKind::ParseError }))
             },
-            Some(u) => {
+            _ => {
                 try!(T::from_str(&b)
                     .map_err(|_| ParseComplexError { kind: ComplexErrorKind::ParseError }))
             }
@@ -802,7 +802,7 @@ impl<T> FromStr for Complex<T> where
                 try!(T::from_str(&b)
                     .map_err(|_| ParseComplexError { kind: ComplexErrorKind::ParseError }))
             },
-            Some(u) => {
+            _ => {
                 a.pop();
                 try!(T::from_str(&a)
                     .map_err(|_| ParseComplexError { kind: ComplexErrorKind::ParseError }))

--- a/complex/src/lib.rs
+++ b/complex/src/lib.rs
@@ -1569,77 +1569,76 @@ mod test {
     }
 
     #[test]
-    fn test_from_string() {
+    fn test_from_str() {
         fn test(z: Complex64, s: String) {
             assert_eq!(FromStr::from_str(&s), Ok(z));
         }
-        test(_0_0i, "0".to_string());
-        test(_0_0i, "0i".to_string());
-        test(_0_0i, "0j".to_string());
-        test(_0_0i, "-0".to_string());
-        test(_0_0i, "-0i".to_string());
-        test(_0_0i, "-0j".to_string());
         test(_0_0i, "0 + 0i".to_string());
-        test(_0_0i, "0 + 0j".to_string());
-        test(_0_0i, "0+0i".to_string());
         test(_0_0i, "0+0j".to_string());
-        test(_0_0i, "0 - 0i".to_string());
         test(_0_0i, "0 - 0j".to_string());
         test(_0_0i, "0-0i".to_string());
-        test(_0_0i, "0-0j".to_string());
+        test(_0_0i, "0i + 0".to_string());
+        test(_0_0i, "0".to_string());
+        test(_0_0i, "-0".to_string());
+        test(_0_0i, "0i".to_string());
+        test(_0_0i, "0j".to_string());
+        test(_0_0i, "-0i".to_string());
 
-        test(_1_0i, "1".to_string());
         test(_1_0i, "1 + 0i".to_string());
-        test(_1_0i, "1 + 0j".to_string());
-        test(_1_0i, "1+0i".to_string());
         test(_1_0i, "1+0j".to_string());
-        test(_1_0i, "1 - 0i".to_string());
         test(_1_0i, "1 - 0j".to_string());
         test(_1_0i, "1-0i".to_string());
-        test(_1_0i, "1-0j".to_string());
+        test(_1_0i, "-0j+1".to_string());
+        test(_1_0i, "1".to_string());
 
         test(_1_1i, "1 + i".to_string());
-        test(_1_1i, "1 + j".to_string());
-        test(_1_1i, "1+i".to_string());
         test(_1_1i, "1+j".to_string());
-        test(_1_1i, "1 + 1i".to_string());
         test(_1_1i, "1 + 1j".to_string());
         test(_1_1i, "1+1i".to_string());
-        test(_1_1i, "1+1j".to_string());
+        test(_1_1i, "i + 1".to_string());
+        test(_1_1i, "1i+1".to_string());
+        test(_1_1i, "j+1".to_string());
 
-        test(_0_1i, "i".to_string());
-        test(_0_1i, "j".to_string());
-        test(_0_1i, "1i".to_string());
-        test(_0_1i, "1j".to_string());
         test(_0_1i, "0 + i".to_string());
-        test(_0_1i, "0 + j".to_string());
-        test(_0_1i, "0+i".to_string());
         test(_0_1i, "0+j".to_string());
-        test(_0_1i, "-0 + i".to_string());
         test(_0_1i, "-0 + j".to_string());
         test(_0_1i, "-0+i".to_string());
-        test(_0_1i, "-0+j".to_string());
         test(_0_1i, "0 + 1i".to_string());
-        test(_0_1i, "0 + 1j".to_string());
-        test(_0_1i, "0+1i".to_string());
         test(_0_1i, "0+1j".to_string());
-        test(_0_1i, "-0 + 1i".to_string());
         test(_0_1i, "-0 + 1j".to_string());
         test(_0_1i, "-0+1i".to_string());
-        test(_0_1i, "-0+1j".to_string());
+        test(_0_1i, "j + 0".to_string());
+        test(_0_1i, "i".to_string());
+        test(_0_1i, "j".to_string());
+        test(_0_1i, "1j".to_string());
 
         test(_neg1_1i, "-1 + i".to_string());
-        test(_neg1_1i, "-1 + j".to_string());
-        test(_neg1_1i, "-1+i".to_string());
         test(_neg1_1i, "-1+j".to_string());
-        test(_neg1_1i, "-1 + 1i".to_string());
         test(_neg1_1i, "-1 + 1j".to_string());
         test(_neg1_1i, "-1+1i".to_string());
-        test(_neg1_1i, "-1+1j".to_string());
+        test(_neg1_1i, "1i-1".to_string());
+        test(_neg1_1i, "j + -1".to_string());
 
         test(_05_05i, "0.5 + 0.5i".to_string());
-        test(_05_05i, "0.5 + 0.5j".to_string());
-        test(_05_05i, "0.5+0.5i".to_string());
         test(_05_05i, "0.5+0.5j".to_string());
+        test(_05_05i, "5e-1+0.5j".to_string());
+        test(_05_05i, "5E-1 + 0.5j".to_string());
+        test(_05_05i, "5E-1i + 0.5".to_string());
+        test(_05_05i, "0.05e+1j + 50E-2".to_string());
+    }
+
+    #[test]
+    fn test_from_str_fail() {
+        fn test(s: &str) {
+            let complex: Result<Complex64, _> = FromStr::from_str(s);
+            assert!(complex.is_err());
+        }
+        test("foo");
+        test("6E");
+        test("0 + 2.718");
+        test("1 - -2i");
+        test("314e-2ij");
+        test("4.3j - i");
+        test("1i - 2i");
     }
 }

--- a/complex/src/lib.rs
+++ b/complex/src/lib.rs
@@ -743,7 +743,7 @@ impl<T> fmt::Binary for Complex<T> where
 }
 
 impl<T> FromStr for Complex<T> where
-    T: FromStr + Num + PartialOrd + Clone, T::Err: Error
+    T: FromStr + Num + Clone
 {
     type Err = ParseComplexError<T::Err>;
 
@@ -861,15 +861,13 @@ impl<T> serde::Deserialize for Complex<T> where
 }
 
 #[derive(Debug, PartialEq)]
-pub struct ParseComplexError<E> where
-    E: Error
+pub struct ParseComplexError<E>
 {
     kind: ComplexErrorKind<E>,
 }
 
 #[derive(Debug, PartialEq)]
-enum ComplexErrorKind<E> where
-    E: Error
+enum ComplexErrorKind<E>
 {
     ParseError(E),
     ExprError

--- a/complex/src/lib.rs
+++ b/complex/src/lib.rs
@@ -750,7 +750,10 @@ impl<T> FromStr for Complex<T> where
     /// Parses `a +/- bi`; `ai +/- b`; `a`; or `bi` where `a` and `b` are of type `T`
     fn from_str(s: &str) -> Result<Complex<T>, ParseComplexError>
     {
-        let imag = 'i';
+        let imag = match s.rfind('j') {
+            None => 'i',
+            _ => 'j'
+        };
 
         let mut a = String::with_capacity(s.len());
         let mut b = String::with_capacity(s.len());
@@ -1572,41 +1575,71 @@ mod test {
         }
         test(_0_0i, "0".to_string());
         test(_0_0i, "0i".to_string());
+        test(_0_0i, "0j".to_string());
         test(_0_0i, "-0".to_string());
         test(_0_0i, "-0i".to_string());
+        test(_0_0i, "-0j".to_string());
         test(_0_0i, "0 + 0i".to_string());
+        test(_0_0i, "0 + 0j".to_string());
         test(_0_0i, "0+0i".to_string());
+        test(_0_0i, "0+0j".to_string());
         test(_0_0i, "0 - 0i".to_string());
+        test(_0_0i, "0 - 0j".to_string());
         test(_0_0i, "0-0i".to_string());
+        test(_0_0i, "0-0j".to_string());
 
         test(_1_0i, "1".to_string());
         test(_1_0i, "1 + 0i".to_string());
+        test(_1_0i, "1 + 0j".to_string());
         test(_1_0i, "1+0i".to_string());
+        test(_1_0i, "1+0j".to_string());
         test(_1_0i, "1 - 0i".to_string());
+        test(_1_0i, "1 - 0j".to_string());
         test(_1_0i, "1-0i".to_string());
+        test(_1_0i, "1-0j".to_string());
 
         test(_1_1i, "1 + i".to_string());
+        test(_1_1i, "1 + j".to_string());
         test(_1_1i, "1+i".to_string());
+        test(_1_1i, "1+j".to_string());
         test(_1_1i, "1 + 1i".to_string());
+        test(_1_1i, "1 + 1j".to_string());
         test(_1_1i, "1+1i".to_string());
+        test(_1_1i, "1+1j".to_string());
 
         test(_0_1i, "i".to_string());
+        test(_0_1i, "j".to_string());
         test(_0_1i, "1i".to_string());
+        test(_0_1i, "1j".to_string());
         test(_0_1i, "0 + i".to_string());
+        test(_0_1i, "0 + j".to_string());
         test(_0_1i, "0+i".to_string());
+        test(_0_1i, "0+j".to_string());
         test(_0_1i, "-0 + i".to_string());
+        test(_0_1i, "-0 + j".to_string());
         test(_0_1i, "-0+i".to_string());
+        test(_0_1i, "-0+j".to_string());
         test(_0_1i, "0 + 1i".to_string());
+        test(_0_1i, "0 + 1j".to_string());
         test(_0_1i, "0+1i".to_string());
+        test(_0_1i, "0+1j".to_string());
         test(_0_1i, "-0 + 1i".to_string());
+        test(_0_1i, "-0 + 1j".to_string());
         test(_0_1i, "-0+1i".to_string());
+        test(_0_1i, "-0+1j".to_string());
 
         test(_neg1_1i, "-1 + i".to_string());
+        test(_neg1_1i, "-1 + j".to_string());
         test(_neg1_1i, "-1+i".to_string());
+        test(_neg1_1i, "-1+j".to_string());
         test(_neg1_1i, "-1 + 1i".to_string());
+        test(_neg1_1i, "-1 + 1j".to_string());
         test(_neg1_1i, "-1+1i".to_string());
+        test(_neg1_1i, "-1+1j".to_string());
 
         test(_05_05i, "0.5 + 0.5i".to_string());
+        test(_05_05i, "0.5 + 0.5j".to_string());
         test(_05_05i, "0.5+0.5i".to_string());
+        test(_05_05i, "0.5+0.5j".to_string());
     }
 }


### PR DESCRIPTION
This commit adds a basic parser for Complex types in Cartesian form, per https://github.com/rust-num/num/issues/289. It will take numbers of the form `a + bi`, `ai + b`, `a - bi`, `ai - b`, `a`, or `ai`. At least one space between the real/imaginary parts and the operator is mandatory; without bringing in a dependency on some regex crate, it's nontrivial to handle cases like, e.g., 0.217828e+1+31.4159E-1, or a similar case with polar coordinates. I could work on these issues later if you like.