### PR TITLE
Add CI badge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/rust-num/num"
 name = "num"
 version = "0.1.40"
 
+[badges]
+travis-ci = { repository = "rust-num/num" }
+
 [[bench]]
 name = "bigint"
 


### PR DESCRIPTION
This adds the CI badge to the pages on crates.io, #323 adds it to the README. Sorry for the separate PRs, but I didn't feel like forking and cloning the repository down to my laptop and simply used the GitHub online editor instead :-)