### PR TITLE
Optimizing BigUint and Bigint multiplication with the Toom-3 algorithm

### DIFF
--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -79,6 +79,11 @@ fn multiply_2(b: &mut Bencher) {
 }
 
 #[bench]
+fn multiply_3(b: &mut Bencher) {
+    multiply_bench(b, 1 << 16, 1 << 17);
+}
+
+#[bench]
 fn divide_0(b: &mut Bencher) {
     divide_bench(b, 1 << 8, 1 << 6);
 }

--- a/bigint/src/algorithms.rs
+++ b/bigint/src/algorithms.rs
@@ -227,16 +227,16 @@ fn mac_digit(acc: &mut [BigDigit], b: &[BigDigit], c: BigDigit) {
     }
 
     let mut carry = 0;
+    let (a_lo, a_hi) = acc.split_at_mut(b.len());
 
-    for (i, bi) in b.iter().enumerate() {
-        acc[i] = mac_with_carry(acc[i], *bi, c, &mut carry);
+    for (a, &b) in a_lo.iter_mut().zip(b) {
+        *a = mac_with_carry(*a, b, c, &mut carry);
     }
 
-    let mut i = b.len();
-
+    let mut a = a_hi.iter_mut();
     while carry != 0 {
-        acc[i] = adc(acc[i], 0, &mut carry);
-        i += 1;
+        let a = a.next().expect("carry overflow during multiplication!");
+        *a = adc(*a, 0, &mut carry);
     }
 }
 

--- a/bigint/src/algorithms.rs
+++ b/bigint/src/algorithms.rs
@@ -260,12 +260,12 @@ fn mac3(acc: &mut [BigDigit], b: &[BigDigit], c: &[BigDigit]) {
     // The thresholds are somewhat arbitrary, chosen by evaluating the results
     // of `cargo bench --bench bigint multiply`.
 
-    if x.len() <= 16 {
+    if x.len() <= 32 {
         // Long multiplication:
         for (i, xi) in x.iter().enumerate() {
             mac_digit(&mut acc[i..], y, *xi);
         }
-    } else if x.len() <= 300 {
+    } else if x.len() <= 256 {
         /*
          * Karatsuba multiplication:
          *

--- a/bigint/src/algorithms.rs
+++ b/bigint/src/algorithms.rs
@@ -394,11 +394,17 @@ fn mac3(acc: &mut [BigDigit], b: &[BigDigit], c: &[BigDigit]) {
         let y1 = BigInt::from_slice(Plus, &y[y0_len..y0_len + y1_len]);
         let y2 = BigInt::from_slice(Plus, &y[y0_len + y1_len..]);
 
+        let p = &x0 + &x2;
+        let q = &y0 + &y2;
+
+        let p2 = &p - &x1;
+        let q2 = &q - &y1;
+
         let r0 = &x0 * &y0;
         let r4 = &x2 * &y2;
-        let r1 = (&x0 + &x1 + &x2) * (&y0 + &y1 + &y2);
-        let r2 = (&x0 - &x1 + &x2) * (&y0 - &y1 + &y2);
-        let r3 = (x0 - x1*2 + x2*4) * (y0 - y1*2 + y2*4);
+        let r1 = (&p + &x1) * (&q + &y1);
+        let r2 = &p2 * &q2;
+        let r3 = ((p2 + x2)*2 - x0) * ((q2 + y2)*2 - y0);
 
         let mut comp3: BigInt = (&r3 - &r1) / 3;
         let mut comp1: BigInt = (&r1 - &r2) / 2;

--- a/bigint/src/algorithms.rs
+++ b/bigint/src/algorithms.rs
@@ -226,20 +226,18 @@ fn mac_digit(acc: &mut [BigDigit], b: &[BigDigit], c: BigDigit) {
         return;
     }
 
-    let mut b_iter = b.iter();
     let mut carry = 0;
 
-    for ai in acc.iter_mut() {
-        if let Some(bi) = b_iter.next() {
-            *ai = mac_with_carry(*ai, *bi, c, &mut carry);
-        } else if carry != 0 {
-            *ai = mac_with_carry(*ai, 0, c, &mut carry);
-        } else {
-            break;
-        }
+    for (i, bi) in b.iter().enumerate() {
+        acc[i] = mac_with_carry(acc[i], *bi, c, &mut carry);
     }
 
-    assert!(carry == 0);
+    let mut i = b.len();
+
+    while carry != 0 {
+        acc[i] = adc(acc[i], 0, &mut carry);
+        i += 1;
+    }
 }
 
 /// Three argument multiply accumulate:

--- a/bigint/src/algorithms.rs
+++ b/bigint/src/algorithms.rs
@@ -408,8 +408,8 @@ fn mac3(acc: &mut [BigDigit], b: &[BigDigit], c: &[BigDigit]) {
         comp1 = comp1 - &comp3;
 
         let result = r0 + (comp1 << 32*i) + (comp2 << 2*32*i) + (comp3 << 3*32*i) + (r4 << 4*32*i);
-        assert!(result.sign != Minus);
-        add2(&mut acc[..], &result.data.data);
+        let result_pos = result.to_biguint().unwrap();
+        add2(&mut acc[..], &result_pos.data);
     }
 }
 

--- a/bigint/src/algorithms.rs
+++ b/bigint/src/algorithms.rs
@@ -417,14 +417,14 @@ fn mac3(acc: &mut [BigDigit], b: &[BigDigit], c: &[BigDigit]) {
 
         let r0 = &x0 * &y0;
         let r4 = &x2 * &y2;
-        let r1 = (&p + &x1) * (&q + &y1);
+        let r1 = (p + x1) * (q + y1);
         let r2 = &p2 * &q2;
         let r3 = ((p2 + x2)*2 - x0) * ((q2 + y2)*2 - y0);
 
-        let mut comp3: BigInt = (&r3 - &r1) / 3;
-        let mut comp1: BigInt = (&r1 - &r2) / 2;
-        let mut comp2: BigInt = &r2 - &r0;
-        comp3 = (&comp2 - &comp3)/2 + &r4*2;
+        let mut comp3: BigInt = (r3 - &r1) / 3;
+        let mut comp1: BigInt = (r1 - &r2) / 2;
+        let mut comp2: BigInt = r2 - &r0;
+        comp3 = (&comp2 - comp3)/2 + &r4*2;
         comp2 = comp2 + &comp1 - &r4;
         comp1 = comp1 - &comp3;
 

--- a/bigint/src/algorithms.rs
+++ b/bigint/src/algorithms.rs
@@ -253,11 +253,11 @@ fn mac3(acc: &mut [BigDigit], b: &[BigDigit], c: &[BigDigit]) {
 
     // Karatsuba multiplication is slower than long multiplication for small x and y:
     //
-    if x.len() <= 4 {
+    if x.len() <= 16 {
         for (i, xi) in x.iter().enumerate() {
             mac_digit(&mut acc[i..], y, *xi);
         }
-    } else if y.len() <= 0 {
+    } else if x.len() <= 300 {
         /*
          * Karatsuba multiplication:
          *
@@ -395,206 +395,21 @@ fn mac3(acc: &mut [BigDigit], b: &[BigDigit], c: &[BigDigit]) {
         let y2 = BigInt::from_slice(Plus, &y[y0_len + y1_len..]);
 
         let r0 = &x0 * &y0;
+        let r4 = &x2 * &y2;
         let r1 = (&x0 + &x1 + &x2) * (&y0 + &y1 + &y2);
         let r2 = (&x0 - &x1 + &x2) * (&y0 - &y1 + &y2);
-        let r3 = (&x0 - &x1*2 + &x2*4) * (&y0 - &y1*2 + &y2*4);
-        let r4 = &x2 * &y2;
+        let r3 = (x0 - x1*2 + x2*4) * (y0 - y1*2 + y2*4);
 
-        let comp0: BigInt = r0.clone();
-        let comp4: BigInt = r4.clone();
         let mut comp3: BigInt = (&r3 - &r1) / 3;
         let mut comp1: BigInt = (&r1 - &r2) / 2;
         let mut comp2: BigInt = &r2 - &r0;
         comp3 = (&comp2 - &comp3)/2 + &r4*2;
-        comp2 = comp2 + &comp1 - &comp4;
+        comp2 = comp2 + &comp1 - &r4;
         comp1 = comp1 - &comp3;
 
-        let result = comp0 + (comp1 << 32*i) + (comp2 << 2*32*i) + (comp3 << 3*32*i) + (comp4 << 4*32*i);
+        let result = r0 + (comp1 << 32*i) + (comp2 << 2*32*i) + (comp3 << 3*32*i) + (r4 << 4*32*i);
         assert!(result.sign != Minus);
         add2(&mut acc[..], &result.data.data);
-
-        // add2(&mut acc[..], &comp0.data.data);
-        // add2(&mut acc[4*i..], &comp4.data.data);
-        //
-        // match (comp1.sign, comp2.sign, comp3.sign) {
-        //     (Minus, Minus, Minus) => {
-        //         for _ in 0..i {
-        //             comp1.data.data.insert(0, 0);
-        //         }
-        //         sub2(&mut acc[..], &comp1.data.data);
-        //
-        //         for _ in 0..2*i {
-        //             comp2.data.data.insert(0, 0);
-        //         }
-        //         sub2(&mut acc[..], &comp2.data.data);
-        //
-        //         for _ in 0..3*i {
-        //             comp3.data.data.insert(0, 0);
-        //         }
-        //         sub2(&mut acc[..], &comp3.data.data);
-        //     },
-        //
-        //     (Minus, Minus, _) => {
-        //         add2(&mut acc[3*i..], &comp3.data.data);
-        //         for _ in 0..i {
-        //             comp1.data.data.insert(0, 0);
-        //         }
-        //         sub2(&mut acc[..], &comp1.data.data);
-        //         for _ in 0..2*i {
-        //             comp2.data.data.insert(0, 0);
-        //         }
-        //         sub2(&mut acc[..], &comp2.data.data);
-        //     },
-        //
-        //     (Minus, _, Minus) => {
-        //         add2(&mut acc[2*i..], &comp2.data.data);
-        //         for _ in 0..i {
-        //             comp1.data.data.insert(0, 0);
-        //         }
-        //         sub2(&mut acc[..], &comp1.data.data);
-        //         for _ in 0..3*i {
-        //             comp3.data.data.insert(0, 0);
-        //         }
-        //         sub2(&mut acc[..], &comp3.data.data);
-        //     },
-        //
-        //     (_, Minus, Minus) => {
-        //         add2(&mut acc[i..], &comp1.data.data);
-        //         for _ in 0..2*i {
-        //             comp2.data.data.insert(0, 0);
-        //         }
-        //         sub2(&mut acc[..], &comp2.data.data);
-        //         for _ in 0..3*i {
-        //             comp3.data.data.insert(0, 0);
-        //         }
-        //         sub2(&mut acc[..], &comp3.data.data);
-        //     },
-        //
-        //     (Minus, _, _) => {
-        //         add2(&mut acc[2*i..], &comp2.data.data);
-        //         add2(&mut acc[3*i..], &comp3.data.data);
-        //         for _ in 0..i {
-        //             comp1.data.data.insert(0, 0);
-        //         }
-        //         sub2(&mut acc[..], &comp1.data.data);
-        //     },
-        //
-        //     (_, Minus, _) => {
-        //         add2(&mut acc[i..], &comp1.data.data);
-        //         add2(&mut acc[3*i..], &comp3.data.data);
-        //         for _ in 0..2*i {
-        //             comp2.data.data.insert(0, 0);
-        //         }
-        //         sub2(&mut acc[..], &comp2.data.data);
-        //     },
-        //
-        //     (_, _, Minus) => {
-        //         add2(&mut acc[i..], &comp1.data.data);
-        //         add2(&mut acc[2*i..], &comp2.data.data);
-        //         for _ in 0..3*i {
-        //             comp3.data.data.insert(0, 0);
-        //         }
-        //         sub2(&mut acc[..], &comp3.data.data);
-        //     },
-        //
-        //     _ => {
-        //         add2(&mut acc[i..], &comp1.data.data);
-        //         add2(&mut acc[2*i..], &comp2.data.data);
-        //         add2(&mut acc[3*i..], &comp3.data.data);
-        //     }
-        // }
-
-        // let mut r0 = BigUint{ data: vec![0; 2*i + 1] };
-        // mac3(&mut r0.data, &x0, &y0);
-        // r0.normalize();
-        //
-        // let mut r1 = BigUint{ data: vec![0; 2*(i+2) + 1] };
-        // p.data.assign_from_slice(&x0);
-        // p.data.data.extend_from_slice(&[0, 0]);
-        // add2(&mut p.data.data, &x1);
-        // add2(&mut p.data.data, &x2);
-        // q.data.assign_from_slice(&y0);
-        // q.data.data.extend_from_slice(&[0, 0]);
-        // add2(&mut q.data.data, &y1);
-        // add2(&mut q.data.data, &y2);
-        // mac3(&mut r1.data, &p.data.data, &q.data.data);
-        // r1.normalize();
-        //
-        // let mut r2 = BigUint{ data: vec![0; 2*(i+1) + 1] };
-        // p.data.assign_from_slice(&x0);
-        // p.data.data.extend_from_slice(&[0, 0]);
-        // add2(&mut p.data, &x2);
-        // p = p - BigInt::from_biguint(Plus, BigUint::from_slice(&x1));
-        // q.data.assign_from_slice(&y0);
-        // q.data.data.extend_from_slice(&[0, 0]);
-        // add2(&mut q.data, &y2);
-        // q = q - BigInt::from_biguint(Plus, BigUint::from_slice(&y1));
-        // mac3(&mut r2.data, &p.data, &q.data);
-        // r2.normalize();
-        // let r2_sign = p_sign * q_sign;
-        //
-        // let mut r3 = BigUint{ data: vec![0; 2*(i+2) + 1] };
-        // p.assign_from_slice(&x0);
-        // p.data.extend_from_slice(&[0, 0]);
-        // let mut temp = BigUint { data: Vec::with_capacity(i + 1) };
-        // temp.assign_from_slice(&x2);
-        // temp = temp * 4_u32;
-        // add2(&mut p.data, &temp.data);
-        // temp.assign_from_slice(&x1);
-        // temp = temp * 2_u32;
-        // if p.data[i] == 0 && p.data[..i].iter().rev().lt(temp.data.iter().rev()) {
-        //     p_sign = Minus;
-        //     let p_temp = p.clone();
-        //     p.assign_from_slice(&temp.data);
-        //     sub2(&mut p.data, &p_temp.data);
-        // } else {
-        //     p_sign = Plus;
-        //     sub2(&mut p.data, &temp.data);
-        // }
-        // q.assign_from_slice(&y0);
-        // q.data.extend_from_slice(&[0, 0]);
-        // temp.assign_from_slice(&y2);
-        // temp = temp * 4_u32;
-        // add2(&mut q.data, &temp.data);
-        // temp.assign_from_slice(&y1);
-        // temp = temp * 2_u32;
-        // if q.data[i] == 0 && q.data[..i].iter().rev().lt(temp.data.iter().rev()) {
-        //     q_sign = Minus;
-        //     let q_temp = q.clone();
-        //     q.assign_from_slice(&temp.data);
-        //     sub2(&mut q.data, &q_temp.data);
-        // } else {
-        //     q_sign = Plus;
-        //     sub2(&mut q.data, &temp.data);
-        // }
-        // mac3(&mut r3.data, &p.data, &q.data);
-        // r3.normalize();
-        // let r3_sign = p_sign * q_sign;
-        //
-        // let mut r4 = BigUint{ data: vec![0; 2*i + 1] };
-        // mac3(&mut r4.data, &x2, &y2);
-        // r4.normalize();
-        //
-        // let signed_r0 = BigInt::from_biguint(Plus, r0);
-        // let signed_r1 = BigInt::from_biguint(Plus, r1);
-        // let signed_r2 = BigInt::from_biguint(r2_sign, r2);
-        // let signed_r3 = BigInt::from_biguint(r3_sign, r3);
-        // let signed_r4 = BigInt::from_biguint(Plus, r4);
-        //
-        // let comp0 = signed_r0.clone();
-        // let comp4 = signed_r4.clone();
-        // let mut comp3: BigInt = (&signed_r3 - &signed_r1) / 3;
-        // let mut comp1: BigInt = (&signed_r1 - &signed_r2) / 2;
-        // let mut comp2 = &signed_r2 - &signed_r0;
-        // comp3 = ((&comp2 - &comp3) / 2) + (&signed_r4 * 2);
-        // comp2 = comp2 + &comp1 - &comp4;
-        // comp1 = comp1 - &comp3;
-        //
-        // add2(&mut acc[..], &comp0.data.data);
-        // add2(&mut acc[i..], &comp1.data.data);
-        // add2(&mut acc[2*i..], &comp2.data.data);
-        // add2(&mut acc[3*i..], &comp3.data.data);
-        // add2(&mut acc[4*i..], &comp4.data.data);
     }
 }
 

--- a/bigint/src/bigint.rs
+++ b/bigint/src/bigint.rs
@@ -105,8 +105,8 @@ impl serde::Deserialize for Sign {
 #[derive(Clone, Debug, Hash)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct BigInt {
-    sign: Sign,
-    data: BigUint,
+    pub(super) sign: Sign,
+    pub(super) data: BigUint,
 }
 
 impl PartialEq for BigInt {

--- a/bigint/src/bigint.rs
+++ b/bigint/src/bigint.rs
@@ -105,8 +105,8 @@ impl serde::Deserialize for Sign {
 #[derive(Clone, Debug, Hash)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct BigInt {
-    pub(super) sign: Sign,
-    pub(super) data: BigUint,
+    sign: Sign,
+    data: BigUint,
 }
 
 impl PartialEq for BigInt {


### PR DESCRIPTION
Hi !

I finally implemented the Toom-3 algorithm ! I first tried to minimize the memory allocations by allocating the `Vec<BigDigit>` myself, as was done for Toom-2, but Toom-3 needs more complex calculations, with negative numbers. So I gave up this method, to use `BigInt` directly, and it's already faster ! I also chose a better threshold for the Toom-2 algorithm.

Before any modification :
```
running 4 tests
test multiply_0        ... bench:         257 ns/iter (+/- 25)
test multiply_1        ... bench:      30,240 ns/iter (+/- 1,651)
test multiply_2        ... bench:   2,752,360 ns/iter (+/- 52,102)
test multiply_3        ... bench:  11,618,575 ns/iter (+/- 266,286)
```

With a better Toom-2 threshold (16 instead of 4) :
```
running 4 tests
test multiply_0        ... bench:         130 ns/iter (+/- 8)
test multiply_1        ... bench:      19,772 ns/iter (+/- 1,083)
test multiply_2        ... bench:   1,340,644 ns/iter (+/- 17,987)
test multiply_3        ... bench:   7,302,854 ns/iter (+/- 82,060)
```

With the Toom-3 algorithm (with a threshold of 300):
```
running 4 tests
test multiply_0        ... bench:         123 ns/iter (+/- 3)
test multiply_1        ... bench:      19,689 ns/iter (+/- 837)
test multiply_2        ... bench:   1,189,589 ns/iter (+/- 29,101)
test multiply_3        ... bench:   3,014,225 ns/iter (+/- 61,222)
```

I think this could be optimized, but it's a first step !