### PR TITLE
Use `Mul` by reference in `pow`

### DIFF
--- a/traits/src/float.rs
+++ b/traits/src/float.rs
@@ -459,13 +459,33 @@ pub trait Float
     /// assert!(abs_difference < 1e-10);
     /// ```
     #[inline]
-    fn powi(mut self, mut exp: i32) -> Self {
-        if exp < 0 {
-            self = self.recip();
-            exp = -exp;
+    fn powi(self, mut exp: i32) -> Self {
+        let mut base = self;
+        if exp == 0 {
+            return Self::one();
+        } else if exp < 0 {
+            base = base.recip();
+            exp = exp.wrapping_neg();
         }
-        // It should always be possible to convert a positive `i32` to a `usize`.
-        super::pow(self, exp.to_usize().unwrap())
+        let mut exp = exp as u32;
+
+        // duplicated from `::pow`, but using `Mul` by value instead of by reference.
+
+        while exp & 1 == 0 {
+            base = base * base;
+            exp >>= 1;
+        }
+        if exp == 1 { return base; }
+
+        let mut acc = base;
+        while exp > 1 {
+            exp >>= 1;
+            base = base * base;
+            if exp & 1 == 1 {
+                acc = acc * base;
+            }
+        }
+        acc
     }
 
     /// Raise a number to a floating point power.

--- a/traits/src/pow.rs
+++ b/traits/src/pow.rs
@@ -12,11 +12,14 @@ use {One, CheckedMul};
 /// assert_eq!(pow(6u8, 3), 216);
 /// ```
 #[inline]
-pub fn pow<T: Clone + One + Mul<T, Output = T>>(mut base: T, mut exp: usize) -> T {
+pub fn pow<T: Clone + One + Mul<T, Output = T>>(mut base: T, mut exp: usize) -> T
+where
+    for<'a> &'a T: Mul<&'a T, Output = T>,
+{
     if exp == 0 { return T::one() }
 
     while exp & 1 == 0 {
-        base = base.clone() * base;
+        base = &base * &base;
         exp >>= 1;
     }
     if exp == 1 { return base }
@@ -24,9 +27,9 @@ pub fn pow<T: Clone + One + Mul<T, Output = T>>(mut base: T, mut exp: usize) -> 
     let mut acc = base.clone();
     while exp > 1 {
         exp >>= 1;
-        base = base.clone() * base;
+        base = &base * &base;
         if exp & 1 == 1 {
-            acc = acc * base.clone();
+            acc = &acc * &base;
         }
     }
     acc

--- a/traits/src/pow.rs
+++ b/traits/src/pow.rs
@@ -12,7 +12,7 @@ use {One, CheckedMul};
 /// assert_eq!(pow(6u8, 3), 216);
 /// ```
 #[inline]
-pub fn pow<T: Clone + One + Mul<T, Output = T>>(mut base: T, mut exp: usize) -> T
+pub fn pow<T: Clone + One>(mut base: T, mut exp: usize) -> T
 where
     for<'a> &'a T: Mul<&'a T, Output = T>,
 {


### PR DESCRIPTION
Resubmission of #153, since it wasn't open to maintainer edits.  I added a distinct `Float::powi` fallback since that doesn't have `Mul` by reference.

cc @dten 