### PR TITLE
Scalar trait: common trait for floating and complex numbers

### DIFF
--- a/complex/src/lib.rs
+++ b/complex/src/lib.rs
@@ -22,7 +22,8 @@ extern crate rustc_serialize;
 #[cfg(feature = "serde")]
 extern crate serde;
 
-pub mod scalar;
+mod scalar;
+pub use scalar::Scalar;
 
 use std::error::Error;
 use std::fmt;

--- a/complex/src/lib.rs
+++ b/complex/src/lib.rs
@@ -22,6 +22,8 @@ extern crate rustc_serialize;
 #[cfg(feature = "serde")]
 extern crate serde;
 
+pub mod scalar;
+
 use std::error::Error;
 use std::fmt;
 #[cfg(test)]

--- a/complex/src/scalar.rs
+++ b/complex/src/scalar.rs
@@ -4,9 +4,22 @@ use std::ops::Neg;
 
 use Complex;
 
-pub trait Scalar: Num + Copy + Neg<Output = Self> {
-    /// Associated Real type
-    type Real: Scalar<Real = Self::Real>;
+pub trait Associated {
+    type Real: Scalar;
+    type Complex: Scalar;
+}
+
+impl<T: Scalar> Associated for T
+where
+    Complex<T::Repr>: Scalar,
+{
+    type Real = T::Repr;
+    type Complex = Complex<T::Repr>;
+}
+
+pub trait Scalar: Num + Copy + Neg<Output = Self> + Associated {
+    /// Associated Repr type
+    type Repr: Scalar<Repr = Self::Repr>;
 
     /// Take the square root of a number.
     fn sqrt(&self) -> Self;
@@ -18,7 +31,7 @@ pub trait Scalar: Num + Copy + Neg<Output = Self> {
     fn ln(&self) -> Self;
 
     /// Returns the square of the absolute value of the number
-    fn abs_sqr(&self) -> Self::Real;
+    fn abs_sqr(&self) -> Self::Repr;
 
     /// Returns the absolute value of the number
     fn abs(&self) -> Self::Real;
@@ -27,10 +40,10 @@ pub trait Scalar: Num + Copy + Neg<Output = Self> {
     fn powi(&self, exp: i32) -> Self;
 
     /// Raise a number to a floating point power.
-    fn powf(&self, exp: Self::Real) -> Self;
+    fn powf(&self, exp: Self::Repr) -> Self;
 
     /// Raise a number to a complex power.
-    fn powc(&self, exp: Complex<Self::Real>) -> Complex<Self::Real>;
+    fn powc(&self, exp: Self::Complex) -> Complex<Self::Repr>;
 
     /// Returns complex-conjugate number
     fn conj(&self) -> Self;
@@ -85,7 +98,7 @@ pub trait Scalar: Num + Copy + Neg<Output = Self> {
 }
 
 impl<T: Clone + Float + FromPrimitive> Scalar for Complex<T> {
-    type Real = T;
+    type Repr = T;
 
     fn sqrt(&self) -> Self {
         Complex::sqrt(self)
@@ -116,7 +129,7 @@ impl<T: Clone + Float + FromPrimitive> Scalar for Complex<T> {
         Complex::powf(self, exp)
     }
 
-    fn powc(&self, exp: Complex<Self::Real>) -> Complex<Self::Real> {
+    fn powc(&self, exp: Self::Complex) -> Self::Complex {
         Complex::powc(self, exp)
     }
 
@@ -189,8 +202,11 @@ impl<T: Clone + Float + FromPrimitive> Scalar for Complex<T> {
     }
 }
 
-impl<T: Float> Scalar for T {
-    type Real = T;
+impl<T: Float> Scalar for T
+where
+    Complex<T>: Scalar,
+{
+    type Repr = T;
 
     fn sqrt(&self) -> Self {
         Float::sqrt(*self)
@@ -220,7 +236,7 @@ impl<T: Float> Scalar for T {
         Float::powf(*self, exp)
     }
 
-    fn powc(&self, exp: Complex<Self::Real>) -> Complex<Self::Real> {
+    fn powc(&self, exp: Self::Complex) -> Self::Complex {
         exp.expf(*self)
     }
 

--- a/complex/src/scalar.rs
+++ b/complex/src/scalar.rs
@@ -1,0 +1,121 @@
+
+use traits::{Num, Float};
+use std::ops::Neg;
+
+use Complex;
+
+pub trait Scalar: Num + Copy + Neg<Output = Self> {
+    /// Associated Real type
+    type Real;
+    /// Associated Complex type
+    type Complex;
+
+    fn sqrt(&self) -> Self;
+    fn exp(&self) -> Self;
+    fn ln(&self) -> Self;
+    fn abs_sqr(&self) -> Self::Real;
+    fn abs(&self) -> Self::Real;
+
+    fn conj(&self) -> Self;
+
+    // trigonometric functions
+    fn sin(&self) -> Self;
+    fn cos(&self) -> Self;
+    fn tan(&self) -> Self;
+    fn asin(&self) -> Self;
+    fn acos(&self) -> Self;
+    fn atan(&self) -> Self;
+
+    // hyperbolic functions
+    fn sinh(&self) -> Self;
+    fn cosh(&self) -> Self;
+    fn tanh(&self) -> Self;
+    fn asinh(&self) -> Self;
+    fn acosh(&self) -> Self;
+    fn atanh(&self) -> Self;
+
+    // check normal
+    fn is_nan(self) -> bool;
+    fn is_infinite(self) -> bool;
+    fn is_finite(self) -> bool;
+    fn is_normal(self) -> bool;
+}
+
+impl<T: Clone + Float> Scalar for Complex<T> {
+    type Real = T;
+    type Complex = Self;
+
+    fn sqrt(&self) -> Self {
+        Complex::sqrt(self)
+    }
+    fn exp(&self) -> Self {
+        Complex::exp(self)
+    }
+    fn ln(&self) -> Self {
+        Complex::ln(self)
+    }
+    fn abs_sqr(&self) -> Self::Real {
+        Complex::norm_sqr(self)
+    }
+    fn abs(&self) -> Self::Real {
+        Complex::norm(self)
+    }
+
+    fn conj(&self) -> Self {
+        Complex::conj(self)
+    }
+
+    // trigonometric functions
+    fn sin(&self) -> Self {
+        Complex::sin(self)
+    }
+    fn cos(&self) -> Self {
+        Complex::cos(self)
+    }
+    fn tan(&self) -> Self {
+        Complex::tan(self)
+    }
+    fn asin(&self) -> Self {
+        Complex::asin(self)
+    }
+    fn acos(&self) -> Self {
+        Complex::acos(self)
+    }
+    fn atan(&self) -> Self {
+        Complex::atan(self)
+    }
+
+    // hyperbolic functions
+    fn sinh(&self) -> Self {
+        Complex::sinh(self)
+    }
+    fn cosh(&self) -> Self {
+        Complex::cosh(self)
+    }
+    fn tanh(&self) -> Self {
+        Complex::tanh(self)
+    }
+    fn asinh(&self) -> Self {
+        Complex::asinh(self)
+    }
+    fn acosh(&self) -> Self {
+        Complex::acosh(self)
+    }
+    fn atanh(&self) -> Self {
+        Complex::atanh(self)
+    }
+
+    // check normal
+    fn is_nan(self) -> bool {
+        Complex::is_nan(self)
+    }
+    fn is_infinite(self) -> bool {
+        Complex::is_infinite(self)
+    }
+    fn is_finite(self) -> bool {
+        Complex::is_finite(self)
+    }
+    fn is_normal(self) -> bool {
+        Complex::is_normal(self)
+    }
+}

--- a/complex/src/scalar.rs
+++ b/complex/src/scalar.rs
@@ -6,7 +6,7 @@ use Complex;
 
 pub trait Scalar: Num + Copy + Neg<Output = Self> {
     /// Associated Real type
-    type Real: Scalar;
+    type Real: Scalar<Real = Self::Real>;
 
     /// Take the square root of a number.
     fn sqrt(&self) -> Self;
@@ -205,7 +205,7 @@ impl<T: Float> Scalar for T {
     }
 
     fn abs_sqr(&self) -> Self::Real {
-        Float::abs(*self).powi(2)
+        *self * *self
     }
 
     fn abs(&self) -> Self::Real {
@@ -221,8 +221,7 @@ impl<T: Float> Scalar for T {
     }
 
     fn powc(&self, exp: Complex<Self::Real>) -> Complex<Self::Real> {
-        let c = Complex::new(*self, T::zero());
-        c.powc(exp)
+        exp.expf(*self)
     }
 
     fn conj(&self) -> Self {

--- a/complex/src/scalar.rs
+++ b/complex/src/scalar.rs
@@ -4,8 +4,11 @@ use std::ops::Neg;
 
 use Complex;
 
+/// Associated types for scalars
 pub trait Associated {
+    /// Real scalar type
     type Real: Scalar;
+    /// Complex scalar type
     type Complex: Scalar;
 }
 
@@ -18,7 +21,7 @@ where
 }
 
 pub trait Scalar: Num + Copy + Neg<Output = Self> + Associated {
-    /// Associated Repr type
+    /// Base floating-point representation of the scalar
     type Repr: Scalar<Repr = Self::Repr>;
 
     /// Take the square root of a number.

--- a/complex/src/scalar.rs
+++ b/complex/src/scalar.rs
@@ -10,19 +10,25 @@ pub trait Scalar: Num + Copy + Neg<Output = Self> {
 
     /// Take the square root of a number.
     fn sqrt(&self) -> Self;
+
     /// Returns `e^(self)`, (the exponential function).
     fn exp(&self) -> Self;
+
     /// Returns the natural logarithm of the number.
     fn ln(&self) -> Self;
+
     /// Returns the square of the absolute value of the number
     fn abs_sqr(&self) -> Self::Real;
+
     /// Returns the absolute value of the number
     fn abs(&self) -> Self::Real;
 
     /// Raise a number to an integer power.
     fn powi(&self, exp: i32) -> Self;
+
     /// Raise a number to a floating point power.
     fn powf(&self, exp: Self::Real) -> Self;
+
     /// Raise a number to a complex power.
     fn powc(&self, exp: Complex<Self::Real>) -> Complex<Self::Real>;
 
@@ -31,36 +37,49 @@ pub trait Scalar: Num + Copy + Neg<Output = Self> {
 
     /// Computes the sine of a number
     fn sin(&self) -> Self;
+
     /// Computes the cosine of a number
     fn cos(&self) -> Self;
+
     /// Computes the tangent of a number
     fn tan(&self) -> Self;
+
     /// Computes the arcsine of a number
     fn asin(&self) -> Self;
+
     /// Computes the arccosine of a number
     fn acos(&self) -> Self;
+
     /// Computes the arctangent of a number
     fn atan(&self) -> Self;
 
     /// Computes the hyperbolic-sine of a number
     fn sinh(&self) -> Self;
+
     /// Computes the hyperbolic-cosine of a number
     fn cosh(&self) -> Self;
+
     /// Computes the hyperbolic-tangent of a number
     fn tanh(&self) -> Self;
+
     /// Computes the hyperbolic-arcsine of a number
     fn asinh(&self) -> Self;
+
     /// Computes the hyperbolic-arccosine of a number
     fn acosh(&self) -> Self;
+
     /// Computes the hyperbolic-arctangent of a number
     fn atanh(&self) -> Self;
 
     /// Checks if the given (real or imaginary part of complex) number is NaN
     fn is_nan(self) -> bool;
+
     /// Checks if the given (real or imaginary part of complex) number is infinite
     fn is_infinite(self) -> bool;
+
     /// Checks if the given number is finite
     fn is_finite(self) -> bool;
+
     /// Checks if the given number is normal
     fn is_normal(self) -> bool;
 }
@@ -71,27 +90,32 @@ impl<T: Clone + Float + FromPrimitive> Scalar for Complex<T> {
     fn sqrt(&self) -> Self {
         Complex::sqrt(self)
     }
+
     fn exp(&self) -> Self {
         Complex::exp(self)
     }
+
     fn ln(&self) -> Self {
         Complex::ln(self)
     }
+
     fn abs_sqr(&self) -> Self::Real {
         Complex::norm_sqr(self)
     }
+
     fn abs(&self) -> Self::Real {
         Complex::norm(self)
     }
 
-    // powers
     fn powi(&self, exp: i32) -> Self {
         let exp = T::from_i32(exp).unwrap();
         Complex::powf(self, exp)
     }
+
     fn powf(&self, exp: Self::Real) -> Self {
         Complex::powf(self, exp)
     }
+
     fn powc(&self, exp: Complex<Self::Real>) -> Complex<Self::Real> {
         Complex::powc(self, exp)
     }
@@ -100,56 +124,66 @@ impl<T: Clone + Float + FromPrimitive> Scalar for Complex<T> {
         Complex::conj(self)
     }
 
-    // trigonometric functions
     fn sin(&self) -> Self {
         Complex::sin(self)
     }
+
     fn cos(&self) -> Self {
         Complex::cos(self)
     }
+
     fn tan(&self) -> Self {
         Complex::tan(self)
     }
+
     fn asin(&self) -> Self {
         Complex::asin(self)
     }
+
     fn acos(&self) -> Self {
         Complex::acos(self)
     }
+
     fn atan(&self) -> Self {
         Complex::atan(self)
     }
 
-    // hyperbolic functions
     fn sinh(&self) -> Self {
         Complex::sinh(self)
     }
+
     fn cosh(&self) -> Self {
         Complex::cosh(self)
     }
+
     fn tanh(&self) -> Self {
         Complex::tanh(self)
     }
+
     fn asinh(&self) -> Self {
         Complex::asinh(self)
     }
+
     fn acosh(&self) -> Self {
         Complex::acosh(self)
     }
+
     fn atanh(&self) -> Self {
         Complex::atanh(self)
     }
 
-    // check normal
     fn is_nan(self) -> bool {
         Complex::is_nan(self)
     }
+
     fn is_infinite(self) -> bool {
         Complex::is_infinite(self)
     }
+
     fn is_finite(self) -> bool {
         Complex::is_finite(self)
     }
+
     fn is_normal(self) -> bool {
         Complex::is_normal(self)
     }
@@ -161,26 +195,31 @@ impl<T: Float> Scalar for T {
     fn sqrt(&self) -> Self {
         Float::sqrt(*self)
     }
+
     fn exp(&self) -> Self {
         Float::exp(*self)
     }
+
     fn ln(&self) -> Self {
         Float::ln(*self)
     }
+
     fn abs_sqr(&self) -> Self::Real {
         Float::abs(*self).powi(2)
     }
+
     fn abs(&self) -> Self::Real {
         Float::abs(*self)
     }
 
-    // powers
     fn powi(&self, exp: i32) -> Self {
         Float::powi(*self, exp)
     }
+
     fn powf(&self, exp: Self::Real) -> Self {
         Float::powf(*self, exp)
     }
+
     fn powc(&self, exp: Complex<Self::Real>) -> Complex<Self::Real> {
         let c = Complex::new(*self, T::zero());
         c.powc(exp)
@@ -190,56 +229,66 @@ impl<T: Float> Scalar for T {
         *self
     }
 
-    // trigonometric functions
     fn sin(&self) -> Self {
         Float::sin(*self)
     }
+
     fn cos(&self) -> Self {
         Float::cos(*self)
     }
+
     fn tan(&self) -> Self {
         Float::tan(*self)
     }
+
     fn asin(&self) -> Self {
         Float::asin(*self)
     }
+
     fn acos(&self) -> Self {
         Float::acos(*self)
     }
+
     fn atan(&self) -> Self {
         Float::atan(*self)
     }
 
-    // hyperbolic functions
     fn sinh(&self) -> Self {
         Float::sinh(*self)
     }
+
     fn cosh(&self) -> Self {
         Float::cosh(*self)
     }
+
     fn tanh(&self) -> Self {
         Float::tanh(*self)
     }
+
     fn asinh(&self) -> Self {
         Float::asinh(*self)
     }
+
     fn acosh(&self) -> Self {
         Float::acosh(*self)
     }
+
     fn atanh(&self) -> Self {
         Float::atanh(*self)
     }
 
-    // check normal
     fn is_nan(self) -> bool {
         Float::is_nan(self)
     }
+
     fn is_infinite(self) -> bool {
         Float::is_infinite(self)
     }
+
     fn is_finite(self) -> bool {
         Float::is_finite(self)
     }
+
     fn is_normal(self) -> bool {
         Float::is_normal(self)
     }

--- a/complex/src/scalar.rs
+++ b/complex/src/scalar.rs
@@ -10,38 +10,60 @@ pub trait Scalar: Num + Copy + Neg<Output = Self> {
     /// Associated Complex type
     type Complex;
 
+    /// Take the square root of a number.
     fn sqrt(&self) -> Self;
+    /// Returns `e^(self)`, (the exponential function).
     fn exp(&self) -> Self;
+    /// Returns the natural logarithm of the number.
     fn ln(&self) -> Self;
+    /// Returns the square of the absolute value of the number
     fn abs_sqr(&self) -> Self::Real;
+    /// Returns the absolute value of the number
     fn abs(&self) -> Self::Real;
 
+    /// Raise a number to an integer power.
     fn powi(&self, exp: i32) -> Self;
+    /// Raise a number to a floating point power.
     fn powf(&self, exp: Self::Real) -> Self;
+    /// Raise a number to a complex power.
     fn powc(&self, exp: Self::Complex) -> Self::Complex;
 
+    /// Returns complex-conjugate number
     fn conj(&self) -> Self;
 
-    // trigonometric functions
+    /// Computes the sine of a number
     fn sin(&self) -> Self;
+    /// Computes the cosine of a number
     fn cos(&self) -> Self;
+    /// Computes the tangent of a number
     fn tan(&self) -> Self;
+    /// Computes the arcsine of a number
     fn asin(&self) -> Self;
+    /// Computes the arccosine of a number
     fn acos(&self) -> Self;
+    /// Computes the arctangent of a number
     fn atan(&self) -> Self;
 
-    // hyperbolic functions
+    /// Computes the hyperbolic-sine of a number
     fn sinh(&self) -> Self;
+    /// Computes the hyperbolic-cosine of a number
     fn cosh(&self) -> Self;
+    /// Computes the hyperbolic-tangent of a number
     fn tanh(&self) -> Self;
+    /// Computes the hyperbolic-arcsine of a number
     fn asinh(&self) -> Self;
+    /// Computes the hyperbolic-arccosine of a number
     fn acosh(&self) -> Self;
+    /// Computes the hyperbolic-arctangent of a number
     fn atanh(&self) -> Self;
 
-    // check normal
+    /// Checks if the given (real or imaginary part of complex) number is NaN
     fn is_nan(self) -> bool;
+    /// Checks if the given (real or imaginary part of complex) number is infinite
     fn is_infinite(self) -> bool;
+    /// Checks if the given number is finite
     fn is_finite(self) -> bool;
+    /// Checks if the given number is normal
     fn is_normal(self) -> bool;
 }
 

--- a/complex/src/scalar.rs
+++ b/complex/src/scalar.rs
@@ -1,5 +1,5 @@
 
-use traits::{Num, Float};
+use traits::{Num, FromPrimitive, Float};
 use std::ops::Neg;
 
 use Complex;
@@ -15,6 +15,10 @@ pub trait Scalar: Num + Copy + Neg<Output = Self> {
     fn ln(&self) -> Self;
     fn abs_sqr(&self) -> Self::Real;
     fn abs(&self) -> Self::Real;
+
+    fn powi(&self, exp: i32) -> Self;
+    fn powf(&self, exp: Self::Real) -> Self;
+    fn powc(&self, exp: Self::Complex) -> Self::Complex;
 
     fn conj(&self) -> Self;
 
@@ -41,7 +45,7 @@ pub trait Scalar: Num + Copy + Neg<Output = Self> {
     fn is_normal(self) -> bool;
 }
 
-impl<T: Clone + Float> Scalar for Complex<T> {
+impl<T: Clone + Float + FromPrimitive> Scalar for Complex<T> {
     type Real = T;
     type Complex = Self;
 
@@ -59,6 +63,18 @@ impl<T: Clone + Float> Scalar for Complex<T> {
     }
     fn abs(&self) -> Self::Real {
         Complex::norm(self)
+    }
+
+    // powers
+    fn powi(&self, exp: i32) -> Self {
+        let exp = T::from_i32(exp).unwrap();
+        Complex::powf(self, exp)
+    }
+    fn powf(&self, exp: Self::Real) -> Self {
+        Complex::powf(self, exp)
+    }
+    fn powc(&self, exp: Self::Complex) -> Self::Complex {
+        Complex::powc(self, exp)
     }
 
     fn conj(&self) -> Self {
@@ -140,6 +156,18 @@ impl<T: Float> Scalar for T {
     }
     fn abs(&self) -> Self::Real {
         Float::abs(*self)
+    }
+
+    // powers
+    fn powi(&self, exp: i32) -> Self {
+        Float::powi(*self, exp)
+    }
+    fn powf(&self, exp: Self::Real) -> Self {
+        Float::powf(*self, exp)
+    }
+    fn powc(&self, exp: Self::Complex) -> Self::Complex {
+        let c = Complex::new(*self, T::zero());
+        c.powc(exp)
     }
 
     fn conj(&self) -> Self {

--- a/complex/src/scalar.rs
+++ b/complex/src/scalar.rs
@@ -4,25 +4,9 @@ use std::ops::Neg;
 
 use Complex;
 
-/// Associated types for scalars
-pub trait Associated {
-    /// Real scalar type
-    type Real: Scalar;
-    /// Complex scalar type
-    type Complex: Scalar;
-}
-
-impl<T: Scalar> Associated for T
-where
-    Complex<T::Repr>: Scalar,
-{
-    type Real = T::Repr;
-    type Complex = Complex<T::Repr>;
-}
-
-pub trait Scalar: Num + Copy + Neg<Output = Self> + Associated {
-    /// Base floating-point representation of the scalar
-    type Repr: Scalar<Repr = Self::Repr>;
+pub trait Scalar: Num + Copy + Neg<Output = Self> {
+    /// Associated Real type
+    type Real: Scalar<Real = Self::Real>;
 
     /// Take the square root of a number.
     fn sqrt(&self) -> Self;
@@ -34,7 +18,7 @@ pub trait Scalar: Num + Copy + Neg<Output = Self> + Associated {
     fn ln(&self) -> Self;
 
     /// Returns the square of the absolute value of the number
-    fn abs_sqr(&self) -> Self::Repr;
+    fn abs_sqr(&self) -> Self::Real;
 
     /// Returns the absolute value of the number
     fn abs(&self) -> Self::Real;
@@ -43,10 +27,10 @@ pub trait Scalar: Num + Copy + Neg<Output = Self> + Associated {
     fn powi(&self, exp: i32) -> Self;
 
     /// Raise a number to a floating point power.
-    fn powf(&self, exp: Self::Repr) -> Self;
+    fn powf(&self, exp: Self::Real) -> Self;
 
     /// Raise a number to a complex power.
-    fn powc(&self, exp: Self::Complex) -> Complex<Self::Repr>;
+    fn powc(&self, exp: Complex<Self::Real>) -> Complex<Self::Real>;
 
     /// Returns complex-conjugate number
     fn conj(&self) -> Self;
@@ -101,7 +85,7 @@ pub trait Scalar: Num + Copy + Neg<Output = Self> + Associated {
 }
 
 impl<T: Clone + Float + FromPrimitive> Scalar for Complex<T> {
-    type Repr = T;
+    type Real = T;
 
     fn sqrt(&self) -> Self {
         Complex::sqrt(self)
@@ -132,7 +116,7 @@ impl<T: Clone + Float + FromPrimitive> Scalar for Complex<T> {
         Complex::powf(self, exp)
     }
 
-    fn powc(&self, exp: Self::Complex) -> Self::Complex {
+    fn powc(&self, exp: Complex<Self::Real>) -> Complex<Self::Real> {
         Complex::powc(self, exp)
     }
 
@@ -205,11 +189,8 @@ impl<T: Clone + Float + FromPrimitive> Scalar for Complex<T> {
     }
 }
 
-impl<T: Float> Scalar for T
-where
-    Complex<T>: Scalar,
-{
-    type Repr = T;
+impl<T: Float> Scalar for T {
+    type Real = T;
 
     fn sqrt(&self) -> Self {
         Float::sqrt(*self)
@@ -239,7 +220,7 @@ where
         Float::powf(*self, exp)
     }
 
-    fn powc(&self, exp: Self::Complex) -> Self::Complex {
+    fn powc(&self, exp: Complex<Self::Real>) -> Complex<Self::Real> {
         exp.expf(*self)
     }
 

--- a/complex/src/scalar.rs
+++ b/complex/src/scalar.rs
@@ -93,7 +93,7 @@ where
     fn is_normal(self) -> bool;
 }
 
-impl<T: Clone + Float + FromPrimitive> Scalar for Complex<T> {
+impl<T: Float + FromPrimitive> Scalar for Complex<T> {
     type Real = T;
     type Complex = Self;
 
@@ -199,7 +199,7 @@ impl<T: Clone + Float + FromPrimitive> Scalar for Complex<T> {
     }
 }
 
-impl<T: Clone + Float + FromPrimitive> Scalar for T {
+impl<T: Float + FromPrimitive> Scalar for T {
     type Real = T;
     type Complex = Complex<T>;
 

--- a/complex/src/scalar.rs
+++ b/complex/src/scalar.rs
@@ -119,3 +119,84 @@ impl<T: Clone + Float> Scalar for Complex<T> {
         Complex::is_normal(self)
     }
 }
+
+impl<T: Float> Scalar for T {
+    /// Associated Real type
+    type Real = T;
+    /// Associated Complex type
+    type Complex = Complex<T>;
+
+    fn sqrt(&self) -> Self {
+        Float::sqrt(*self)
+    }
+    fn exp(&self) -> Self {
+        Float::exp(*self)
+    }
+    fn ln(&self) -> Self {
+        Float::ln(*self)
+    }
+    fn abs_sqr(&self) -> Self::Real {
+        Float::abs(*self).powi(2)
+    }
+    fn abs(&self) -> Self::Real {
+        Float::abs(*self)
+    }
+
+    fn conj(&self) -> Self {
+        *self
+    }
+
+    // trigonometric functions
+    fn sin(&self) -> Self {
+        Float::sin(*self)
+    }
+    fn cos(&self) -> Self {
+        Float::cos(*self)
+    }
+    fn tan(&self) -> Self {
+        Float::tan(*self)
+    }
+    fn asin(&self) -> Self {
+        Float::asin(*self)
+    }
+    fn acos(&self) -> Self {
+        Float::acos(*self)
+    }
+    fn atan(&self) -> Self {
+        Float::atan(*self)
+    }
+
+    // hyperbolic functions
+    fn sinh(&self) -> Self {
+        Float::sinh(*self)
+    }
+    fn cosh(&self) -> Self {
+        Float::cosh(*self)
+    }
+    fn tanh(&self) -> Self {
+        Float::tanh(*self)
+    }
+    fn asinh(&self) -> Self {
+        Float::asinh(*self)
+    }
+    fn acosh(&self) -> Self {
+        Float::acosh(*self)
+    }
+    fn atanh(&self) -> Self {
+        Float::atanh(*self)
+    }
+
+    // check normal
+    fn is_nan(self) -> bool {
+        Float::is_nan(self)
+    }
+    fn is_infinite(self) -> bool {
+        Float::is_infinite(self)
+    }
+    fn is_finite(self) -> bool {
+        Float::is_finite(self)
+    }
+    fn is_normal(self) -> bool {
+        Float::is_normal(self)
+    }
+}

--- a/complex/src/scalar.rs
+++ b/complex/src/scalar.rs
@@ -6,9 +6,7 @@ use Complex;
 
 pub trait Scalar: Num + Copy + Neg<Output = Self> {
     /// Associated Real type
-    type Real;
-    /// Associated Complex type
-    type Complex;
+    type Real: Scalar;
 
     /// Take the square root of a number.
     fn sqrt(&self) -> Self;
@@ -26,7 +24,7 @@ pub trait Scalar: Num + Copy + Neg<Output = Self> {
     /// Raise a number to a floating point power.
     fn powf(&self, exp: Self::Real) -> Self;
     /// Raise a number to a complex power.
-    fn powc(&self, exp: Self::Complex) -> Self::Complex;
+    fn powc(&self, exp: Complex<Self::Real>) -> Complex<Self::Real>;
 
     /// Returns complex-conjugate number
     fn conj(&self) -> Self;
@@ -69,7 +67,6 @@ pub trait Scalar: Num + Copy + Neg<Output = Self> {
 
 impl<T: Clone + Float + FromPrimitive> Scalar for Complex<T> {
     type Real = T;
-    type Complex = Self;
 
     fn sqrt(&self) -> Self {
         Complex::sqrt(self)
@@ -95,7 +92,7 @@ impl<T: Clone + Float + FromPrimitive> Scalar for Complex<T> {
     fn powf(&self, exp: Self::Real) -> Self {
         Complex::powf(self, exp)
     }
-    fn powc(&self, exp: Self::Complex) -> Self::Complex {
+    fn powc(&self, exp: Complex<Self::Real>) -> Complex<Self::Real> {
         Complex::powc(self, exp)
     }
 
@@ -159,10 +156,7 @@ impl<T: Clone + Float + FromPrimitive> Scalar for Complex<T> {
 }
 
 impl<T: Float> Scalar for T {
-    /// Associated Real type
     type Real = T;
-    /// Associated Complex type
-    type Complex = Complex<T>;
 
     fn sqrt(&self) -> Self {
         Float::sqrt(*self)
@@ -187,7 +181,7 @@ impl<T: Float> Scalar for T {
     fn powf(&self, exp: Self::Real) -> Self {
         Float::powf(*self, exp)
     }
-    fn powc(&self, exp: Self::Complex) -> Self::Complex {
+    fn powc(&self, exp: Complex<Self::Real>) -> Complex<Self::Real> {
         let c = Complex::new(*self, T::zero());
         c.powc(exp)
     }

--- a/complex/src/scalar.rs
+++ b/complex/src/scalar.rs
@@ -4,9 +4,18 @@ use std::ops::Neg;
 
 use Complex;
 
-pub trait Scalar: Num + Copy + Neg<Output = Self> {
+pub trait Scalar: Num + Copy + Neg<Output = Self>
+where
+    Complex<Self::Real>: Scalar<
+        Real = Self::Real,
+        Complex = Complex<Self::Real>,
+    >,
+{
     /// Associated Real type
-    type Real: Scalar<Real = Self::Real>;
+    type Real: Scalar<Real = Self::Real, Complex = Complex<Self::Real>>;
+
+    /// Associated Complex type
+    type Complex: Scalar<Real = Self::Real, Complex = Complex<Self::Real>>;
 
     /// Take the square root of a number.
     fn sqrt(&self) -> Self;
@@ -86,6 +95,7 @@ pub trait Scalar: Num + Copy + Neg<Output = Self> {
 
 impl<T: Clone + Float + FromPrimitive> Scalar for Complex<T> {
     type Real = T;
+    type Complex = Self;
 
     fn sqrt(&self) -> Self {
         Complex::sqrt(self)
@@ -189,8 +199,9 @@ impl<T: Clone + Float + FromPrimitive> Scalar for Complex<T> {
     }
 }
 
-impl<T: Float> Scalar for T {
+impl<T: Clone + Float + FromPrimitive> Scalar for T {
     type Real = T;
+    type Complex = Complex<T>;
 
     fn sqrt(&self) -> Self {
         Float::sqrt(*self)


### PR DESCRIPTION
Related to #321 (or resolve it?)

I introduce a trait `Scalar` to use `Complex` and `Float` transparently.
Most of numerical functions (e.g. `sin`) are defined both in the `Float` trait and `Complex`. It is not useful to implement an algorithm which can accept both floating and complex numbers (e.g. most of matrix manipulation in [ndarray-linalg](https://github.com/termoshtt/ndarray-linalg))