### PR TITLE
Fix documentation formatting with commonmark enabled

### DIFF
--- a/bigint/src/bigint.rs
+++ b/bigint/src/bigint.rs
@@ -1366,7 +1366,7 @@ impl<R: Rng> RandBigInt for R {
 impl BigInt {
     /// Creates and initializes a BigInt.
     ///
-    /// The digits are in little-endian base 2^32.
+    /// The digits are in little-endian base 2<sup>32</sup>.
     #[inline]
     pub fn new(sign: Sign, digits: Vec<BigDigit>) -> BigInt {
         BigInt::from_biguint(sign, BigUint::new(digits))
@@ -1374,7 +1374,7 @@ impl BigInt {
 
     /// Creates and initializes a `BigInt`.
     ///
-    /// The digits are in little-endian base 2^32.
+    /// The digits are in little-endian base 2<sup>32</sup>.
     #[inline]
     pub fn from_biguint(mut sign: Sign, mut data: BigUint) -> BigInt {
         if sign == NoSign {
@@ -1444,7 +1444,7 @@ impl BigInt {
     /// Creates and initializes a `BigInt` from an array of bytes in
     /// two's complement binary representation.
     ///
-    /// The digits are in big-endian base 2^8.
+    /// The digits are in big-endian base 2<sup>8</sup>.
     #[inline]
     pub fn from_signed_bytes_be(digits: &[u8]) -> BigInt {
         let sign = match digits.first() {
@@ -1465,7 +1465,7 @@ impl BigInt {
 
     /// Creates and initializes a `BigInt` from an array of bytes in two's complement.
     ///
-    /// The digits are in little-endian base 2^8.
+    /// The digits are in little-endian base 2<sup>8</sup>.
     #[inline]
     pub fn from_signed_bytes_le(digits: &[u8]) -> BigInt {
         let sign = match digits.last() {

--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -1325,7 +1325,7 @@ pub fn to_str_radix_reversed(u: &BigUint, radix: u32) -> Vec<u8> {
 impl BigUint {
     /// Creates and initializes a `BigUint`.
     ///
-    /// The digits are in little-endian base 2^32.
+    /// The digits are in little-endian base 2<sup>32</sup>.
     #[inline]
     pub fn new(digits: Vec<BigDigit>) -> BigUint {
         BigUint { data: digits }.normalized()
@@ -1333,7 +1333,7 @@ impl BigUint {
 
     /// Creates and initializes a `BigUint`.
     ///
-    /// The digits are in little-endian base 2^32.
+    /// The digits are in little-endian base 2<sup>32</sup>.
     #[inline]
     pub fn from_slice(slice: &[BigDigit]) -> BigUint {
         BigUint::new(slice.to_vec())
@@ -1341,7 +1341,7 @@ impl BigUint {
 
     /// Assign a value to a `BigUint`.
     ///
-    /// The digits are in little-endian base 2^32.
+    /// The digits are in little-endian base 2<sup>32</sup>.
     #[inline]
     pub fn assign_from_slice(&mut self, slice: &[BigDigit]) {
         self.data.resize(slice.len(), 0);

--- a/complex/src/lib.rs
+++ b/complex/src/lib.rs
@@ -132,8 +132,8 @@ impl<T: Clone + Float> Complex<T> {
     pub fn arg(&self) -> T {
         self.im.atan2(self.re)
     }
-    /// Convert to polar form (r, theta), such that `self = r * exp(i
-    /// * theta)`
+    /// Convert to polar form (r, theta), such that
+    /// `self = r * exp(i * theta)`
     #[inline]
     pub fn to_polar(&self) -> (T, T) {
         (self.norm(), self.arg())


### PR DESCRIPTION
This makes formatting correct with the new pulldown-cmark Markdown parser (rust-lang/rust#44229).