### PR TITLE
rational: check for NaN when approximating floats

### DIFF
--- a/rational/src/lib.rs
+++ b/rational/src/lib.rs
@@ -774,7 +774,7 @@ fn approximate_float_unsigned<T, F>(val: F, max_error: F, max_iterations: usize)
     // Continued fractions algorithm
     // http://mathforum.org/dr.math/faq/faq.fractions.html#decfrac
 
-    if val < F::zero() {
+    if val < F::zero() || val.is_nan() {
         return None;
     }
 


### PR DESCRIPTION
We had a test for NaN already, but thanks to undefined casts (#119) it
was only passing by luck -- on armv7hl it failed:

https://bugzilla.redhat.com/show_bug.cgi?id=1511187

Now we check for NaN explicitly.