### PR TITLE
[WIP] Make Shr for negative BigInt round down, like primitives do

### DIFF
--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -1656,6 +1656,14 @@ impl BigUint {
     }
 }
 
+pub fn trailing_zeros(u: &BigUint) -> Option<usize> {
+    u.data
+        .iter()
+        .enumerate()
+        .find(|&(_, &digit)| digit != 0)
+        .map(|(i, digit)| i * big_digit::BITS + digit.trailing_zeros() as usize)
+}
+
 #[cfg(feature = "serde")]
 impl serde::Serialize for BigUint {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>

--- a/bigint/src/tests/bigint.rs
+++ b/bigint/src/tests/bigint.rs
@@ -1192,3 +1192,28 @@ fn test_negative_rand_range() {
     // Switching u and l should fail:
     let _n: BigInt = rng.gen_bigint_range(&u, &l);
 }
+
+#[test]
+fn test_negative_shr() {
+    assert_eq!(BigInt::from(-1) >> 1, BigInt::from(-1));
+    assert_eq!(BigInt::from(-2) >> 1, BigInt::from(-1));
+    assert_eq!(BigInt::from(-3) >> 1, BigInt::from(-2));
+    assert_eq!(BigInt::from(-3) >> 2, BigInt::from(-1));
+}
+
+#[test]
+fn test_random_shr() {
+    use rand::Rng;
+    let mut rng = thread_rng();
+
+    for p in rng.gen_iter::<i64>().take(1000) {
+        let big = BigInt::from(p);
+        let bigger = &big << 1000;
+        assert_eq!(&bigger >> 1000, big);
+        for i in 0..64 {
+            let answer = BigInt::from(p >> i);
+            assert_eq!(&big >> i, answer);
+            assert_eq!(&bigger >> (1000 + i), answer);
+        }
+    }
+}


### PR DESCRIPTION
Primitive integers always round down when shifting right, but `BigInt`
was effectively rounding toward zero, because it just kept its sign and
used the `BigUint` magnitude rounded down (always toward zero).

Now we adjust the result of shifting negative values, and explicitly
test that it matches the result for primitive integers.

Fixes #347.