### PR TITLE
Avoid large intermediate product in LCM

### DIFF
--- a/bigint/src/biguint.rs
+++ b/bigint/src/biguint.rs
@@ -955,7 +955,7 @@ impl Integer for BigUint {
     /// Calculates the Lowest Common Multiple (LCM) of the number and `other`.
     #[inline]
     fn lcm(&self, other: &BigUint) -> BigUint {
-        ((self * other) / self.gcd(other))
+        self / self.gcd(other) * other
     }
 
     /// Deprecated, use `is_multiple_of` instead.


### PR DESCRIPTION
Changed the implementation of BigUint LCM from
`((self * other) / self.gcd(other))`
to
`self / self.gcd(other) * other`

The division is exact in both cases, so the result is the same, but the new code avoids the potentially-large intermediate product, speeding things up and using less memory.

I also removed the unnecessary parentheses, because I think it's clear what order everything will be executed in. But if others think differently I can add them back.