### PR TITLE
derive: update dependencies

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/rust-num/num"
 version = "0.1.41"
 
 [dependencies]
-quote = "0.1.3"
-syn = "0.7.0"
+quote = "0.3.15"
+syn = "0.11.11"
 
 [dev-dependencies]
 compiletest_rs = "0.2.5"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -18,6 +18,8 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 
 use syn::Body::Enum;
+use syn::ConstExpr::Lit;
+use syn::Lit::Int;
 use syn::VariantData::Unit;
 
 #[proc_macro_derive(FromPrimitive)]
@@ -42,8 +44,8 @@ pub fn from_primitive(input: TokenStream) -> TokenStream {
                     panic!("`FromPrimitive` can be applied only to unitary enums, {}::{} is either struct or tuple", name, ident)
                 },
             }
-            if let Some(val) = variant.discriminant {
-                idx = val.value;
+            if let Some(Lit(Int(value, _))) = variant.discriminant {
+                idx = value;
             }
             let tt = quote!(#idx => Some(#name::#ident));
             idx += 1;
@@ -91,8 +93,8 @@ pub fn to_primitive(input: TokenStream) -> TokenStream {
                     panic!("`ToPrimitive` can be applied only to unitary enums, {}::{} is either struct or tuple", name, ident)
                 },
             }
-            if let Some(val) = variant.discriminant {
-                idx = val.value;
+            if let Some(Lit(Int(value, _))) = variant.discriminant {
+                idx = value;
             }
             let tt = quote!(#name::#ident => #idx);
             idx += 1;


### PR DESCRIPTION
Fixes #352.

Newer versions support new syntax, such as pub(restricted).