### PR TITLE
[0.1] Disable `rustc-serialize` derives for future compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ rust:
   - nightly
 matrix:
   include:
-    - rust: 1.8.0
+    - rust: 1.19.0
       before_script:
-        # rand 0.3.22 started depending on rand 0.4, which requires rustc 1.15
-        # manually hacking the lockfile due to the limitations of cargo#2773
         - cargo generate-lockfile
-        - sed -i -e 's/"rand 0.[34].[0-9]\+/"rand 0.3.20/' Cargo.lock
-        - sed -i -e '/^name = "rand"/,/^$/s/version = "0.3.[0-9]\+"/version = "0.3.20"/' Cargo.lock
+        - cargo update -p num-iter --precise 0.1.43
+        - cargo update -p num-integer --precise 0.1.45
+        - cargo update -p num-traits --precise 0.2.15
+        - cargo update -p libc --precise 0.2.163
 sudo: false
 script:
   - cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = [ "algorithms", "data-structures", "science" ]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-num/num"
 name = "num"
-version = "0.1.42"
+version = "0.1.43"
 readme = "README.md"
 
 [badges]
@@ -18,11 +18,11 @@ travis-ci = { repository = "rust-num/num" }
 
 [dependencies.num-bigint]
 optional = true
-version = "0.1.42"
+version = "0.1.45"
 
 [dependencies.num-complex]
 optional = true
-version = "0.1.42"
+version = "0.1.44"
 
 [dependencies.num-integer]
 version = "0.1.36"
@@ -32,7 +32,7 @@ version = "0.1.35"
 
 [dependencies.num-rational]
 optional = true
-version = "0.1.42"
+version = "0.1.43"
 
 [dependencies.num-traits]
 version = "0.2.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crate](https://img.shields.io/crates/v/num.svg)](https://crates.io/crates/num)
 [![documentation](https://docs.rs/num/badge.svg)](https://docs.rs/num)
-![minimum rustc 1.8](https://img.shields.io/badge/rustc-1.8+-red.svg)
+![minimum rustc 1.19](https://img.shields.io/badge/rustc-1.19+-red.svg)
 [![Travis status](https://travis-ci.org/rust-num/num.svg?branch=master)](https://travis-ci.org/rust-num/num)
 
 A collection of numeric types and traits for Rust.
@@ -57,5 +57,4 @@ Release notes are available in [RELEASES.md](RELEASES.md).
 
 ## Compatibility
 
-Most of the `num` crates are tested for rustc 1.8 and greater.
-The exception is `num-derive` which requires at least rustc 1.15.
+The `num` crate is tested for rustc 1.19 and greater.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,9 @@
+# Release 0.1.43
+
+- [Disable `rustc-serialize` derives for future compilers.][441]
+
+[441]: https://github.com/rust-num/num/pull/441
+
 # Release 0.1.42
 
 - [All of the num sub-crates now have their own source repositories][num-356].

--- a/ci/rustup.sh
+++ b/ci/rustup.sh
@@ -1,18 +1,18 @@
 #!/bin/sh
 # Use rustup to locally run the same suite of tests as .travis.yml.
-# (You should first install/update 1.8.0, stable, beta, and nightly.)
+# (You should first install/update 1.19.0, stable, beta, and nightly.)
 
 set -ex
 
 export TRAVIS_RUST_VERSION
-for TRAVIS_RUST_VERSION in 1.8.0 stable beta nightly; do
+for TRAVIS_RUST_VERSION in 1.19.0 stable beta nightly; do
     run="rustup run $TRAVIS_RUST_VERSION"
-    if [ "$TRAVIS_RUST_VERSION" = 1.8.0 ]; then
-      # rand 0.3.22 started depending on rand 0.4, which requires rustc 1.15
-      # manually hacking the lockfile due to the limitations of cargo#2773
-      $run cargo generate-lockfile
-      $run sed -i -e 's/"rand 0.[34].[0-9]\+/"rand 0.3.20/' Cargo.lock
-      $run sed -i -e '/^name = "rand"/,/^$/s/version = "0.3.[0-9]\+"/version = "0.3.20"/' Cargo.lock
+    $run cargo generate-lockfile
+    if [ "$TRAVIS_RUST_VERSION" = 1.19.0 ]; then
+      $run cargo update -p num-iter --precise 0.1.43
+      $run cargo update -p num-integer --precise 0.1.45
+      $run cargo update -p num-traits --precise 0.2.15
+      $run cargo update -p libc --precise 0.2.163
     fi
     $run cargo build --verbose
     $run $PWD/ci/test_full.sh

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 //!
 //! ## Compatibility
 //!
-//! The `num` crate is tested for rustc 1.8 and greater.
+//! The `num` crate is tested for rustc 1.19 and greater.
 
 #![doc(html_root_url = "https://docs.rs/num/0.1")]
 


### PR DESCRIPTION
The built-in derives are being [removed], but crater showed problems
with crates depending on `num v0.1`, where this feature is enabled by
default. With this PR, we detect the missing built-ins and disable the
derives, adding a build-script warning about it. Cargo won't show such
warnings by default from non-path dependencies, unless the build fails.

For `num` itself, this mostly just amounts to a dependency bump.

[removed]: https://github.com/rust-lang/rust/pull/134272
